### PR TITLE
Add the initial runner CLI and first output comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Project-specific paths
+dist/
+node_modules/
+test/output/
+
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -1,3 +1,97 @@
+# AutoRest Compare
+
+`autorest-compare` provides a regression testing tool which can compare the
+output of two AutoRest runs to determine whether there are any material changes
+to the generated source for a given service spec.  Comparisons can be made between:
+
+- Versions of the AutoRest CLI (v2 versus v3)
+- Versions of AutoRest Core
+- Versions of the AutoRest modeler
+- Versions of a language generator
+
+The primary use case for this tool is to determine whether changes to the
+[AutoRest v3 modeler](https://github.com/Azure/autorest.modelerfour) have
+changed the output of the various language generators in undesirable ways.
+
+## Installation
+
+This tool is written for Node.js [Node.js](https://nodejs.org/en/), so make sure
+to have that installed before continuing (we recommend 10.16.x LTS).
+
+With Node.js installed, you can install `autorest-compare` by running the
+following command:
+
+```shell
+npm install -g @autorest/compare
+```
+
+If you'd prefer not to install this tool globally, you can use the following
+command to invoke it with [`npx`] on a one-shot basis:
+
+```
+npx @autorest/compare [arguments]
+```
+
+**NOTE:** Some dependencies contain native code components that need to be
+compiled before they can be used so you'll need to have the appropriate C
+compiler and Python 2.7/3.5 or greater installed on your machine before using
+this tool.
+
+### Windows
+
+If you don't already have Python and the MS Visual Studio C++ compiler tools
+installed, you can easily install them with the following command:
+
+```shell
+npm install --global windows-build-tools
+```
+
+### Linux
+
+Install gcc and  . For Debian/Ubuntu, the following command should work:
+
+```shell
+sudo apt-get install build-essential python
+```
+
+### macOS
+
+On macOS, Python should be installed by default.  The C/C++ compiler can be
+installed with XCode by running the following command:
+
+```shell
+xcode-select --install
+```
+
+## Running `autorest-compare`
+
+Running `autorest-compare --help` will display the list of arguments you might
+wish to use.  Specific usage scenarios are described in the following sections.
+
+* Comparing the Python output between two versions of `@autorest/modelerfour`:
+
+  ```shell
+  autorest-compare --python --spec-path path/to/spec.json \
+    --output-path path/to/output
+    --compare-base --beta --use:@autorest/modelerfour@4.1.59 \
+    --compare-next --beta --use:@autorest/modelerfour@4.1.60
+  ```
+
+* Comparing the TypeScript output of generating all of the specs in the
+  `azure-rest-api-specs` repository between AutoRest v2 and AutoRest v3
+  (/beware/, this takes a while):
+
+  ```shell
+  autorest-compare --typescript --use-azure-specs \
+    --output-path path/to/output
+    --compare-base \
+    --compare-next --beta
+  ```
+
+## How it Works
+
+> TODO: Fill this in.
+
 
 # Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@autorest/autorest": {
-      "version": "3.0.6141",
-      "resolved": "https://registry.npmjs.org/@autorest/autorest/-/autorest-3.0.6141.tgz",
-      "integrity": "sha512-uux6/JbtvPRXG8+waGc2HK68wyJLJ8umeBFiUSgJGkyI85AiAMWHrq0dtI98iUPMrdd7vQz18mCVBqmfDrl43w=="
+      "version": "3.0.6146",
+      "resolved": "https://registry.npmjs.org/@autorest/autorest/-/autorest-3.0.6146.tgz",
+      "integrity": "sha512-K+2u+CyT6EKb9loGqHE5forJTqVH9042ivJQcLzKaH9CrJWkF5jF2LYBHu8ffszyHv6vLQuHSUNgM6Km2kdkbQ=="
     },
     "@types/node": {
       "version": "12.12.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,20 @@
+{
+  "name": "@autorest/compare",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/node": {
+      "version": "12.12.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
+      "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
+      "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
+      "dev": true
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,82 @@
       "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==",
       "dev": true
     },
+    "arg": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz",
+      "integrity": "sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==",
+      "dev": true
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+      "dev": true
+    },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+      "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "tree-sitter-typescript": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.15.1.tgz",
+      "integrity": "sha512-xntREG9BE+zknNgcwmeVuq5/AT+lVCSUKvhX6T6KoZLk5OPY5EfHrTqGTxS97KDlSRiGfGPheOPMNzIgk/kwNQ==",
+      "requires": {
+        "nan": "^2.10.0"
+      }
+    },
+    "ts-node": {
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
+      "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^3.0.0"
+      }
+    },
     "typescript": {
       "version": "3.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
       "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@autorest/autorest": {
+      "version": "3.0.6141",
+      "resolved": "https://registry.npmjs.org/@autorest/autorest/-/autorest-3.0.6141.tgz",
+      "integrity": "sha512-uux6/JbtvPRXG8+waGc2HK68wyJLJ8umeBFiUSgJGkyI85AiAMWHrq0dtI98iUPMrdd7vQz18mCVBqmfDrl43w=="
+    },
     "@types/node": {
       "version": "12.12.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@autorest/compare",
+  "version": "0.1.0",
+  "description": "Compares the output between two AutoRest runs to check for material differences.",
+  "main": "dist/index.js",
+  "bin": {
+    "autorest-compare": "dist/index.js"
+  },
+  "scripts": {
+    "start": "ts-node index.ts",
+    "build": "tsc -p ."
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Azure/autorest.compare.git"
+  },
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Azure/autorest.compare/issues"
+  },
+  "homepage": "https://github.com/Azure/autorest.compare#readme",
+  "dependencies": {
+    "tree-sitter-typescript": "^0.15.1"
+  },
+  "devDependencies": {
+    "@types/node": "^12.12.14",
+    "ts-node": "^8.5.4",
+    "typescript": "^3.7.3"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/Azure/autorest.compare#readme",
   "dependencies": {
-    "@autorest/autorest": "^3.0.6141",
+    "@autorest/autorest": "^3.0.6146",
     "tree-sitter-typescript": "^0.15.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "start": "ts-node src/index.ts",
+    "test-run": "ts-node src/index.ts --typescript --spec-path:redis/resource-manager --spec-root-path:../azure-rest-api-specs/specification --output-path:generated/ --compare-base --version:^2.0.0 --compare-next --version:3.0.6170",
     "build": "tsc -p ."
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "autorest-compare": "dist/index.js"
   },
   "scripts": {
-    "start": "ts-node index.ts",
+    "start": "ts-node src/index.ts",
     "build": "tsc -p ."
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/Azure/autorest.compare#readme",
   "dependencies": {
+    "@autorest/autorest": "^3.0.6141",
     "tree-sitter-typescript": "^0.15.1"
   },
   "devDependencies": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { AutoRestOptions } from "./runner";
+
+/**
+ * Parses an argument of one of the following forms and returns the argument and
+ * possible value as a tuple:
+ *
+ * --arg (value is 'true')
+ * --arg=value
+ * --arg:value (same as above)
+ */
+export function parseArgument(argument: string): [string, string] {
+  const match = /^--([^=:]+)([=:](.+))?$/g.exec(argument);
+  if (match) {
+    return [match[1], match[3] || "true"];
+  } else {
+    throw Error(`Unexpected argument string: ${argument}`);
+  }
+}
+
+/**
+ * Builds an AutoRestOptions instance from the arguments contained in the args
+ * array, stopping when an argument may indicate a different option set.
+ */
+export function getAutoRestOptionsFromArgs(
+  args: string[]
+): [AutoRestOptions, string[]] {
+  const options: AutoRestOptions = {
+    useArgs: []
+  };
+
+  while (args.length > 0) {
+    const arg = args.shift();
+    const [argName, argValue] = parseArgument(arg);
+
+    if (argName === "compare-base" || argName === "compare-next") {
+      args.unshift(arg);
+    } else if (argName === "version") {
+      options.version = argValue;
+    } else if (argName === "beta") {
+      options.useBeta = argValue === "true";
+    } else if (argName === "use") {
+      options.useArgs.push(argValue);
+    } else if (argName === "debug") {
+      options.debug = argValue === "true";
+    }
+  }
+
+  return [options, args];
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,7 @@ export function getAutoRestOptionsFromArgs(
 
     if (argName === "compare-base" || argName === "compare-next") {
       args.unshift(arg);
+      break;
     } else if (argName === "version") {
       options.version = argValue;
     } else if (argName === "beta") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,8 +40,6 @@ export function getAutoRestOptionsFromArgs(
       break;
     } else if (argName === "version") {
       options.version = argValue;
-    } else if (argName === "beta") {
-      options.useBeta = argValue === "true";
     } else if (argName === "use") {
       options.useArgs.push(argValue);
     } else if (argName === "debug") {

--- a/src/comparers.ts
+++ b/src/comparers.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { setDifference } from "./util";
+import { AutoRestResult } from "./runner";
+
+export type Comparer = (baseResult: AutoRestResult, nextResult: AutoRestResult) => Promise<void>;
+
+/**
+ * Compares the outputFiles of two AutoRestResults to see if there are any
+ * unique files contained in either output.
+ */
+export async function compareFileSets(
+  baseResult: AutoRestResult,
+  nextResult: AutoRestResult
+): Promise<void> {
+  const baseFileSet = new Set(baseResult.outputFiles);
+  const nextFileSet = new Set(nextResult.outputFiles);
+  const ignoredFiles = new Set(["code-model-v1"]);
+
+  const baseUniqueFiles = setDifference(
+    setDifference(baseFileSet, nextFileSet),
+    ignoredFiles
+  );
+
+  const nextUniqueFiles = setDifference(
+    setDifference(nextFileSet, baseFileSet),
+    ignoredFiles
+  );
+
+  if (baseUniqueFiles.size > 0 || nextUniqueFiles.size > 0) {
+    throw new Error(`Generated output has different file sets.
+
+Base Output Unique Files:
+
+${Array.from(baseUniqueFiles).join("\n")}
+Next Output Unique Files:
+
+${Array.from(nextUniqueFiles).join("\n")}
+`);
+  }
+}
+
+/**
+ * Compares the timeElapsed of two AutoRestResults to see if the AutoRest
+ * runtime has improved or degraded between the two runs.
+ */
+export async function compareDuration(
+  baseResult: AutoRestResult,
+  nextResult: AutoRestResult
+): Promise<void> {
+  // TODO: Write some logic for this
+}
+
+/**
+ * Returns the default set of comparers.
+ */
+export function getDefaultComparers(): Comparer[] {
+  return [
+    compareFileSets,
+    compareDuration
+  ];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,152 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as path from "path";
+import { getDefaultComparers } from "./comparers";
+import { parseArgument, getAutoRestOptionsFromArgs } from "./cli";
+import {
+  runAutoRest,
+  AutoRestOptions,
+  AutoRestLanguage,
+  AutoRestLanguages
+} from "./runner";
+
+async function main(): Promise<void> {
+  let args = process.argv.slice(2);
+  const languageArgsString = ["", ...AutoRestLanguages].join("\n  --");
+
+  // First, check for the --help parameter, or no parameters at all
+  if (args.length === 0 || args[0] === "--help") {
+    console.log(
+      `
+Usage: autorest-compare --language [spec arguments] --output-path=[generated output path] --compare-base [run arguments] --compare-next [run arguments]
+
+Language Arguments
+${languageArgsString}
+
+Spec Arguments
+
+  --spec-path=<path to .json or spec folder>   Use the specified spec path for code generation
+  --azure-specs[=""]                           Use the azure-rest-api-specs repository for code generation.
+                                               The value of this parameter can either be a comma-separated list
+                                               of relative paths under the 'specifications' folder of this repository
+                                               or omitted entirely to generate code for every spec in the repository.
+
+Output Arguments
+
+  --output-path=[generated output path]        The path where generated source files will be omitted.  This should
+                                               generally be under a temporary file path.
+Comparison Arguments
+
+  --compare-base [run arguments]               Indicates that what follows are arguments for the base of the comparison
+  --compare-next [run arguments]               Indicates that what follows are arguments for the next/new result for
+                                               the comparison.
+
+Run Arguments
+
+  --use:<package@version>                      Use a specific AutoRest core, language, or extension package
+  --beta                                       Use the 'autorest-beta' (AutoRest v3) command instead of 'autorest'
+  --debug                                      Write debug output for the AutoRest run
+
+`.trimLeft()
+    );
+  } else {
+    // TODO: Accept this as a CLI parameter
+    const specsToGenerate = ["redis/resource-manager"];
+
+    const specRepoRoot = path.resolve(
+      __dirname,
+      "../../..",
+      "azure-rest-api-specs"
+    );
+
+    // Build configuration from arguments
+    let language: AutoRestLanguage | undefined;
+    let baseCompareOptions: AutoRestOptions = {};
+    let nextCompareOptions: AutoRestOptions = {};
+
+    while (args.length > 0) {
+      const [argName] = parseArgument(args.shift());
+      if (argName === `compare-base`) {
+        [baseCompareOptions, args] = getAutoRestOptionsFromArgs(args);
+      } else if (argName === `compare-next`) {
+        [nextCompareOptions, args] = getAutoRestOptionsFromArgs(args);
+      } else if (AutoRestLanguages.indexOf(argName as AutoRestLanguage) > -1) {
+        language = argName as AutoRestLanguage;
+      }
+    }
+
+    if (language === undefined) {
+      throw new Error(
+        `Missing language parameter.  Please use one of the following:\n${[
+          "",
+          ...AutoRestLanguages
+        ].join("\n    --")}\n`
+      );
+    }
+
+    console.log(`*** Comparing output of ${language} generator...`);
+
+    for (const specPath of specsToGenerate) {
+      const fullSpecPath = path.resolve(
+        specRepoRoot,
+        "specification",
+        specPath
+      );
+      const outputPath = path.resolve(
+        __dirname,
+        "generated",
+        language,
+        specPath
+      );
+
+      console.log("*** Generating code for spec at path:", fullSpecPath);
+
+      // Run two instances of AutoRest simultaneously
+      const baseRunPromise = runAutoRest(
+        language,
+        fullSpecPath,
+        path.join(outputPath, "base"),
+        baseCompareOptions
+      );
+      const nextRunPromise = runAutoRest(
+        language,
+        fullSpecPath,
+        path.join(outputPath, "next"),
+        nextCompareOptions
+      );
+
+      const [baseResult, nextResult] = await Promise.all([
+        baseRunPromise,
+        nextRunPromise
+      ]);
+
+      if (baseCompareOptions.debug) {
+        console.log("\nBase AutoRest Output:\n");
+        console.log(baseResult.processOutput);
+      }
+      if (nextCompareOptions.debug) {
+        console.log("\nNext AutoRest Output:\n");
+        console.log(nextResult.processOutput);
+      }
+
+      console.log("*** Generation complete, comparing results...");
+
+      for (const comparer of getDefaultComparers()) {
+        await comparer(baseResult, nextResult);
+      }
+
+      console.log(
+        "\nComparison complete, no meaningful differences detected!\n"
+      );
+    }
+  }
+}
+
+main().catch(err => {
+  console.error(
+    "\nAn error occurred while running the validation script:\n\n",
+    err.toString()
+  );
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,6 @@ Comparison Arguments
 Run Arguments
 
   --use:<package@version>                      Use a specific AutoRest core, language, or extension package
-  --beta                                       Use the 'autorest-beta' (AutoRest v3) command instead of 'autorest'
   --debug                                      Write debug output for the AutoRest run
 
 `.trimLeft()

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -9,7 +9,6 @@ import { getPathsRecursively } from "./util";
  * Defines options that will be passed along to the AutoRest run.
  */
 export interface AutoRestOptions {
-  useBeta?: boolean;
   useArgs?: string[];
   version?: string;
   debug?: boolean;
@@ -94,7 +93,6 @@ export async function runAutoRest(
     }
 
     const startTime = Date.now();
-
     const autoRestProcess = cp.fork(autoRestCommand, args, { stdio: "pipe" });
 
     let normalOutput = "";

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,0 +1,132 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as path from "path";
+import * as cp from "child_process";
+import { getPathsRecursively } from "./util";
+
+/**
+ * Defines options that will be passed along to the AutoRest run.
+ */
+export interface AutoRestOptions {
+  useBeta?: boolean;
+  useArgs?: string[];
+  version?: string;
+  debug?: boolean;
+}
+
+/**
+ * Describes different aspects of the result of an AutoRest run.
+ */
+export interface AutoRestResult {
+  version: string;
+  outputPath: string;
+  outputFiles: string[];
+  processOutput: string;
+  timeElapsed: number;
+}
+
+/**
+ * The names of all supported AutoRest language generators.
+ */
+export type AutoRestLanguage =
+  | "typescript"
+  | "python"
+  | "java"
+  | "csharp"
+  | "powershell"
+  | "go";
+
+/**
+ * A list of the names of all supported AutoRest language generators.
+ */
+export const AutoRestLanguages: AutoRestLanguage[] = [
+  "typescript",
+  "python",
+  "java",
+  "csharp",
+  "powershell",
+  "go"
+];
+
+/**
+ * Invokes AutoRest asynchronously as a separate process, passing along the
+ * specified options.  Returns a Promise that carries an AutoRestResult which
+ * describes the result of the run.
+ */
+export async function runAutoRest(
+  language: AutoRestLanguage,
+  specPath: string,
+  outputPath: string,
+  options: AutoRestOptions
+): Promise<AutoRestResult> {
+  return new Promise((resolve, reject) => {
+    const autoRestCommand =
+      options.useBeta === true ? "autorest-beta" : "autorest";
+
+    const args = [
+      // The AutoRest version, if specified
+      ...(options.version ? [`--version=${options.version}`] : []),
+
+      // The language generator to use
+      `--${language}`,
+
+      // The --use flags to pass along
+      ...(options.useArgs || []).map(useSpec => `--use=${useSpec}`),
+
+      // The output-folder where generated files go
+      `--${language}.output-folder=\"${outputPath}\"`,
+
+      // Clear the output folder before generating
+      `--${language}.clear-output-folder`,
+
+      // The path to the input spec
+      specPath,
+
+      // The --debug flag, if requested
+      ...(options.debug ? ["--debug"] : [])
+    ];
+
+    if (options.debug) {
+      console.log(`*** Invoking ${autoRestCommand} with args:`, args);
+    }
+
+    const startTime = Date.now();
+
+    const autoRestProcess = cp.spawn(autoRestCommand, args);
+
+    let normalOutput = "";
+    autoRestProcess.stdout.on("data", data => {
+      normalOutput += data.toString();
+    });
+
+    let errorOutput = "";
+    autoRestProcess.stderr.on("data", data => {
+      errorOutput += data.toString();
+    });
+
+    autoRestProcess.on("exit", exitCode => {
+      if (exitCode > 0) {
+        reject(
+          new Error(
+            `AutoRest (${
+              options.version
+            }) exited with non-zero code:\n\n${errorOutput || normalOutput}`
+          )
+        );
+      }
+
+      const timeElapsed = Date.now() - startTime;
+
+      resolve({
+        version: options.version,
+        outputPath,
+        outputFiles: getPathsRecursively(outputPath).map(p =>
+          path.relative(outputPath, p)
+        ),
+        processOutput: normalOutput,
+        timeElapsed
+      });
+    });
+  });
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -61,8 +61,10 @@ export async function runAutoRest(
   options: AutoRestOptions
 ): Promise<AutoRestResult> {
   return new Promise((resolve, reject) => {
-    const autoRestCommand =
-      options.useBeta === true ? "autorest-beta" : "autorest";
+    const autoRestCommand = path.resolve(
+      __dirname,
+      "../node_modules/.bin/autorest-beta"
+    );
 
     const args = [
       // The AutoRest version, if specified
@@ -93,7 +95,7 @@ export async function runAutoRest(
 
     const startTime = Date.now();
 
-    const autoRestProcess = cp.spawn(autoRestCommand, args);
+    const autoRestProcess = cp.fork(autoRestCommand, args, { stdio: "pipe" });
 
     let normalOutput = "";
     autoRestProcess.stdout.on("data", data => {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Returns a Set containing the items in setA that are not contained within
+ * setB.
+ */
+export function setDifference(setA: Set<string>, setB: Set<string>): Set<string> {
+  const diff = new Set(setA);
+  for (let item of setB) {
+    diff.delete(item);
+  }
+
+  return diff;
+}
+
+/**
+ * Returns a flat list of file paths recursively under the specified folderPath.
+ */
+export function getPathsRecursively(folderPath: string): string[] {
+  let filesInPath = [];
+  for (const childPath of fs.readdirSync(folderPath)) {
+    const rootedPath = path.join(folderPath, childPath);
+    if (fs.statSync(rootedPath).isDirectory()) {
+      filesInPath = filesInPath.concat(getPathsRecursively(rootedPath));
+    } else {
+      filesInPath.push(rootedPath);
+    }
+  }
+
+  return filesInPath;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "noErrorTruncation": true,
+    "noImplicitAny": false,
+    "module": "commonjs",
+    "sourceMap": true,
+    "newLine": "LF",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "downlevelIteration": true,
+    "declaration": true,
+    "stripInternal": true,
+    "target": "es6",
+    "lib": [
+      "es5",
+      "es2015.collection",
+      "es2015.iterable"
+    ]
+  },
+  "exclude": [
+    "dist",
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
This PR establishes the AutoRest runner, CLI interface, and initial comparison framework that will be used to compare the output of two AutoRest runs.  Note that I haven't started to write code comparison logic just yet, the first comparer just checks to see whether there are any files that exist in one output that don't exist in the other.

What do you think about the argument names?  `--compare-base` and `--compare-next` don't seem like perfect names to me so I'm definitely open to suggestions.  I've considered `--compare-left` and `--compare-right` but that seemed more vague