### PR TITLE
Implement initial semantic diff algorithm for TypeScript with Tree Sitter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@autorest/autorest": {
-      "version": "3.0.6146",
-      "resolved": "https://registry.npmjs.org/@autorest/autorest/-/autorest-3.0.6146.tgz",
-      "integrity": "sha512-K+2u+CyT6EKb9loGqHE5forJTqVH9042ivJQcLzKaH9CrJWkF5jF2LYBHu8ffszyHv6vLQuHSUNgM6Km2kdkbQ=="
+      "version": "3.0.6149",
+      "resolved": "https://registry.npmjs.org/@autorest/autorest/-/autorest-3.0.6149.tgz",
+      "integrity": "sha512-kaKm+P+5gDancs1r/T0ghnM/OT5Qmimy2cwvgqzz0IqldXoS4UfQPpeu06Atg8IYqqZbfVzOrQSZVyRIwLnNxw=="
     },
     "@types/color-name": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,11 @@
       "resolved": "https://registry.npmjs.org/@autorest/autorest/-/autorest-3.0.6146.tgz",
       "integrity": "sha512-K+2u+CyT6EKb9loGqHE5forJTqVH9042ivJQcLzKaH9CrJWkF5jF2LYBHu8ffszyHv6vLQuHSUNgM6Km2kdkbQ=="
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -138,23 +143,47 @@
       "dev": true
     },
     "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "dependencies": {
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
+        "ansi-styles": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
+          "integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -622,6 +651,28 @@
       "dev": true,
       "requires": {
         "chalk": "^2.0.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "make-error": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,120 @@
       "resolved": "https://registry.npmjs.org/@autorest/autorest/-/autorest-3.0.6146.tgz",
       "integrity": "sha512-K+2u+CyT6EKb9loGqHE5forJTqVH9042ivJQcLzKaH9CrJWkF5jF2LYBHu8ffszyHv6vLQuHSUNgM6Km2kdkbQ=="
     },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
+      "dev": true,
+      "optional": true
+    },
+    "@types/mocha": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+      "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "12.12.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.14.tgz",
       "integrity": "sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==",
       "dev": true
     },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
     "arg": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz",
       "integrity": "sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "bl": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.0.tgz",
+      "integrity": "sha512-EUAyP5UHU5hxF8BPT0LKW8gjYLhq1DQIcneOX/pL/m2Alo+OYDQAJlHq+yseMP50Os2nHXOSic6Ss3vSQeyf4A==",
+      "requires": {
+        "readable-stream": "^3.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "buffer-from": {
@@ -27,11 +131,498 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "chownr": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decompress-response": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+      "requires": {
+        "mimic-response": "^2.0.0"
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+    },
     "diff": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
       "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
       "dev": true
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "es-abstract": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.3.tgz",
+      "integrity": "sha512-WtY7Fx5LiOnSYgF5eg/1T+GONaGmpvpPdCpSnYij+U2gDTL0UPfWrhDw7b2IYb+9NQJsYpCA0wOQvZfsd6YwRw==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "string.prototype.trimleft": "^2.1.0",
+        "string.prototype.trimright": "^2.1.0"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
     },
     "make-error": {
       "version": "1.3.5",
@@ -39,10 +630,331 @@
       "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
       "dev": true
     },
+    "mimic-response": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
+      "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.2.tgz",
+      "integrity": "sha512-FgDS9Re79yU1xz5d+C4rv1G7QagNGHZ+iXF81hO8zY35YZZcLEsJVfFolfsqKFWunATEvNzMK0r/CwWd/szO9A==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "2.2.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.5",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.0",
+        "yargs-parser": "13.1.1",
+        "yargs-unparser": "1.6.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
+    },
     "nan": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
       "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    },
+    "napi-build-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
+      "integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA=="
+    },
+    "node-abi": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.13.0.tgz",
+      "integrity": "sha512-9HrZGFVTR5SOu3PZAnAY2hLO36aW1wmA+FDsVkr85BTST32TLCA1H/AEcatVRAsWLyXS3bqUDYCAjq5/QGuSTA==",
+      "requires": {
+        "semver": "^5.4.1"
+      }
+    },
+    "node-environment-flags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      }
+    },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "p-limit": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "prebuild-install": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz",
+      "integrity": "sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==",
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^3.0.3",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+    },
+    "simple-get": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+      "requires": {
+        "decompress-response": "^4.2.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -60,12 +972,174 @@
         "source-map": "^0.6.0"
       }
     },
-    "tree-sitter-typescript": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.15.1.tgz",
-      "integrity": "sha512-xntREG9BE+zknNgcwmeVuq5/AT+lVCSUKvhX6T6KoZLk5OPY5EfHrTqGTxS97KDlSRiGfGPheOPMNzIgk/kwNQ==",
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "requires": {
-        "nan": "^2.10.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "optional": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "supports-color": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "tar-fs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
+      "integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
+      }
+    },
+    "tar-stream": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.0.tgz",
+      "integrity": "sha512-+DAn4Nb4+gz6WZigRzKEZl1QuJVOLtAwwF+WUxy1fJ6X63CaGaUAxJRD2KEn1OMfcbCjySTYpNC6WmfQoIEOdw==",
+      "requires": {
+        "bl": "^3.0.0",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "tree-sitter": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.16.0.tgz",
+      "integrity": "sha512-Iprnr33uQKdpFTT2ceMUwlacjutdtz34us8S8ztqMo2cSKIwDC8BakZAOURFg6Sy4mGUC6G/b6BlBw3RlDj4xQ==",
+      "requires": {
+        "nan": "^2.14.0",
+        "prebuild-install": "^5.0.0"
+      }
+    },
+    "tree-sitter-typescript": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.16.1.tgz",
+      "integrity": "sha512-jyU5yl4W6JPn66v2YbzaO1ClDcdDnj+7YQNZz3STgEiUooSjpWI1Ucgw+S/qEGbf0fMXsC0fucpP+/M1uc9ubw==",
+      "requires": {
+        "nan": "^2.14.0"
+      }
+    },
+    "ts-mocha": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-6.0.0.tgz",
+      "integrity": "sha512-ZCtJK8WXxHNbFNjvUKQIXZby/+ybQQkaBcM/3QhBQUfwjpdGFE9F6iWsHhF5ifQNFV/lWiOODi2VMD5AyPcQyg==",
+      "dev": true,
+      "requires": {
+        "ts-node": "7.0.1",
+        "tsconfig-paths": "^3.5.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "ts-node": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+          "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.0",
+            "buffer-from": "^1.1.0",
+            "diff": "^3.1.0",
+            "make-error": "^1.1.1",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.5.6",
+            "yn": "^2.0.0"
+          }
+        },
+        "yn": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+          "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+          "dev": true
+        }
       }
     },
     "ts-node": {
@@ -81,11 +1155,191 @@
         "yn": "^3.0.0"
       }
     },
+    "tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "typescript": {
       "version": "3.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.3.tgz",
       "integrity": "sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==",
       "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+      "dev": true,
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
+      }
     },
     "yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/Azure/autorest.compare#readme",
   "dependencies": {
-    "@autorest/autorest": "^3.0.6146",
+    "@autorest/autorest": "^3.0.6149",
     "chalk": "^3.0.0",
     "tree-sitter": "^0.16.0",
     "tree-sitter-typescript": "^0.16.1"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "start": "ts-node src/index.ts",
+    "test:unit": "ts-mocha -p tsconfig.json test/**/*.spec.ts",
     "test-run": "ts-node src/index.ts --typescript --spec-path:redis/resource-manager --spec-root-path:../azure-rest-api-specs/specification --output-path:generated/ --compare-base --version:^2.0.0 --compare-next --version:3.0.6170",
     "build": "tsc -p ."
   },
@@ -23,10 +24,14 @@
   "homepage": "https://github.com/Azure/autorest.compare#readme",
   "dependencies": {
     "@autorest/autorest": "^3.0.6146",
-    "tree-sitter-typescript": "^0.15.1"
+    "tree-sitter": "^0.16.0",
+    "tree-sitter-typescript": "^0.16.1"
   },
   "devDependencies": {
+    "@types/mocha": "^5.2.7",
     "@types/node": "^12.12.14",
+    "mocha": "^6.2.2",
+    "ts-mocha": "^6.0.0",
     "ts-node": "^8.5.4",
     "typescript": "^3.7.3"
   }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/Azure/autorest.compare#readme",
   "dependencies": {
     "@autorest/autorest": "^3.0.6146",
+    "chalk": "^3.0.0",
     "tree-sitter": "^0.16.0",
     "tree-sitter-typescript": "^0.16.1"
   },

--- a/src/comparers.ts
+++ b/src/comparers.ts
@@ -24,7 +24,7 @@ export interface NamedItem {
  * An item with an order identifier.  This is used when an item should have
  * its list order taken into consideration when being compared.
  */
-export interface OrderedItem {
+export interface OrderedItem extends NamedItem {
   ordinal: number;
 }
 
@@ -198,6 +198,24 @@ export function compareItems<TItem extends NamedItem>(
   }
 
   return prepareResult(resultMessage, messageType, messages);
+}
+
+/**
+ * Compares two arrays of strings using `compareItems` as the underlying
+ * algorithm.
+ */
+export function compareStrings(
+  resultMessage: string,
+  oldItems: string[] | undefined,
+  newItems: string[] | undefined
+): CompareResult {
+  return compareItems(
+    resultMessage,
+    MessageType.Outline,
+    (oldItems || []).map(name => ({ name })),
+    (newItems || []).map(name => ({ name })),
+    (o, n) => undefined
+  );
 }
 
 /**

--- a/src/comparers.ts
+++ b/src/comparers.ts
@@ -4,39 +4,93 @@
 import * as path from "path";
 import { AutoRestResult } from "./runner";
 
+/**
+ * A function which compares two items and returns a CompareResult.
+ */
 export type Comparer<TItem extends NamedItem> = (
   oldItem: TItem,
   newItem: TItem
 ) => CompareResult;
 
+/**
+ * An item with a name.  The name is typically used to compare lists
+ * of similar items to determine whether one exists in both lists.
+ */
 export interface NamedItem {
   name: string;
 }
 
+/**
+ * An item with an order identifier.  This is used when an item should have
+ * its list order taken into consideration when being compared.
+ */
 export interface OrderedItem {
   ordinal: number;
 }
 
+/**
+ * Describes details of a specific file, particularly its name (relative path
+ * and file name) and the base path from which relative paths can be resolved.
+ */
 export interface FileDetails {
   name: string;
   basePath: string;
 }
 
+/**
+ * Enumerates the types of messages that may be emitted.
+ */
 export enum MessageType {
+  /**
+   * An outline message for organizational purposes.
+   */
   Outline,
+
+  /**
+   * A message that indicates an item was added.
+   */
   Added,
+
+  /**
+   * A message that indicates an item was removed.
+   */
   Removed,
+
+  /**
+   * A message that indicates an item has changed.
+   */
   Changed
 }
 
+/**
+ * Describes a message that is emitted from a comparison of two semantic
+ * elements in the generated source.  The total comparison output is treated as
+ * an outline where nodes can have children which report differences
+ * recursively.
+ */
 export type CompareMessage = {
+  /**
+   * The message describing this
+   */
   message: string;
+
+  /**
+   * The MessageType that indicates what kind of message is conveyed.
+   */
   type: MessageType;
+
+  /**
+   * The child messages that provide futher comparison granularity.
+   */
   children?: CompareMessage[];
 };
 
 export type CompareResult = CompareMessage | undefined;
 
+/**
+ * Simplifies the creation of a `CompareResult` which only needs to be returned
+ * when there are child messages for a comparison output.
+ */
 export function prepareResult(
   message: string,
   messageType: MessageType,
@@ -52,6 +106,22 @@ export function prepareResult(
     : undefined;
 }
 
+/**
+ * Compares two lists of items, reporting on any items that are added or removed
+ * in the new list and the differences between items with the same name that
+ * exist in both lists.  If `isOrderSignificant` is passed, items with an
+ * `ordinal` property have their list order compared so that reorderings can be
+ * reported.
+ *
+ * @param resultMessage The message for the CompareResult that is returned from
+ *                      this comparison.
+ * @param messageType   The type of message returned from this comparison.
+ * @param oldItems      The array of "old" items to compare against.
+ * @param newItems      The array of "new" items to compare from.
+ * @param compareFunc   The Comparer to use when comparing items that exist in both arrays.
+ * @param isOrderSignificant When true, the `ordinal` field of two items is also
+                             considered during comparisons.
+ */
 export function compareItems<TItem extends NamedItem>(
   resultMessage: string,
   messageType: MessageType,
@@ -130,6 +200,10 @@ export function compareItems<TItem extends NamedItem>(
   return prepareResult(resultMessage, messageType, messages);
 }
 
+/**
+ * Performs a strict comparison of two values and returns a message
+ * reporting the difference, if any.
+ */
 export function compareValue(
   message: string,
   oldValue: any,
@@ -162,6 +236,10 @@ export interface CompareSourceOptions {
   comparersByType: ComparerIndex;
 }
 
+/**
+ * Compares two files which are considered to be the same (having the same file
+ * path) using a comparer that is selected based on the file's extension.
+ */
 export function compareFile(
   oldFile: FileDetails,
   newFile: FileDetails,
@@ -172,6 +250,9 @@ export function compareFile(
   return comparer ? comparer(oldFile, newFile) : undefined;
 }
 
+/**
+ * Compares the set of output files for two AutoRest runs.
+ */
 export function compareOutputFiles(
   baseResult: AutoRestResult,
   nextResult: AutoRestResult,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,14 +2,55 @@
 // Licensed under the MIT License.
 
 import * as path from "path";
-import { getDefaultComparers } from "./comparers";
+import { compareOutputFiles } from "./comparers";
+import { compareFile as compareTypeScriptFile } from "./languages/typescript";
+import { printCompareMessage } from "./printer";
 import { parseArgument, getAutoRestOptionsFromArgs } from "./cli";
 import {
   runAutoRest,
+  OutputDetails,
   AutoRestOptions,
   AutoRestLanguage,
   AutoRestLanguages
 } from "./runner";
+
+interface CompareRun {
+  fullSpecPath?: string;
+  baseOutput: OutputDetails;
+  nextOutput: OutputDetails;
+}
+
+function getRunsFromSpecPaths(
+  specPaths: string[],
+  specRootPath: string | undefined,
+  baseOutput: OutputDetails,
+  nextOutput: OutputDetails
+): CompareRun[] {
+  const runs: CompareRun[] = [];
+
+  for (const specPath of specPaths) {
+    const fullSpecPath = path.resolve(specRootPath || ".", specPath);
+    runs.push({
+      fullSpecPath,
+      baseOutput: {
+        ...baseOutput,
+        outputPath: path.join(
+          baseOutput.outputPath,
+          specRootPath ? specPath : ""
+        )
+      },
+      nextOutput: {
+        ...nextOutput,
+        outputPath: path.join(
+          nextOutput.outputPath,
+          specRootPath ? specPath : ""
+        )
+      }
+    });
+  }
+
+  return runs;
+}
 
 async function main(): Promise<void> {
   let args = process.argv.slice(2);
@@ -35,21 +76,35 @@ Spec Arguments
 Output Arguments
 
   --output-path=[generated output path]        The path where generated source files will be omitted.  This should
-                                               generally be under a temporary file path.
+                                               generally be under a temporary file path.  When a --spec-root-path
+                                               is provided, the path --spec-path relative to the --spec-root-path
+                                               will be used as the subpath of the --output-path.
+
 Comparison Arguments
 
-  --compare-base [run arguments]               Indicates that what follows are arguments for the base of the comparison
+  --compare-base[:path] [run arguments]        Indicates that what follows are arguments for the base of the comparison.
+                                               You may also pass a path to an existing folder of output from a previous
+                                               AutoRest run: --compare-base:path/to/existing/output.  If a --spec-root-path
+                                               is provided, it is expected that the existing output will be located
+                                               in a subpath equal to the relative path of a --spec-path parameter and
+                                               the --spec-root-path.
+
+                                               NOTE: When you use an existing output path, all following arguments for
+                                               --compare-base will be ignored.
+
   --compare-next [run arguments]               Indicates that what follows are arguments for the next/new result for
                                                the comparison.
 
 Run Arguments
 
   --use:<package@version>                      Use a specific AutoRest core, language, or extension package
-  --debug                                      Write debug output for the AutoRest run
+  --debug                                      Write debug output for the AutoRest run (can be used globally or within
+                                               the arguments of a specific comparison)
 
 `.trimLeft()
     );
   } else {
+    let debug = false;
     const specPaths = [];
     let outputPath: string | undefined;
     let specRootPath: string | undefined;
@@ -59,22 +114,51 @@ Run Arguments
     let baseCompareOptions: AutoRestOptions = {};
     let nextCompareOptions: AutoRestOptions = {};
 
+    let baseOutputDetails: OutputDetails | undefined;
+    let nextOutputDetails: OutputDetails | undefined;
+
     while (args.length > 0) {
       const [argName, argValue] = parseArgument(args.shift());
       if (argName === `compare-base`) {
-        [baseCompareOptions, args] = getAutoRestOptionsFromArgs(args);
+        if (argValue) {
+          baseOutputDetails = {
+            outputPath: argValue,
+            useExisting: true
+          };
+        } else {
+          [baseCompareOptions, args] = getAutoRestOptionsFromArgs(args);
+        }
       } else if (argName === `compare-next`) {
-        [nextCompareOptions, args] = getAutoRestOptionsFromArgs(args);
+        if (argValue) {
+          nextOutputDetails = {
+            outputPath: argValue,
+            useExisting: true
+          };
+        } else {
+          [nextCompareOptions, args] = getAutoRestOptionsFromArgs(args);
+        }
       } else if (argName === `spec-path`) {
         specPaths.push(argValue);
       } else if (argName === `spec-root-path`) {
         specRootPath = argValue;
       } else if (argName === `output-path`) {
         outputPath = argValue;
+      } else if (argName === "debug") {
+        debug = argValue === "true";
       } else if (AutoRestLanguages.indexOf(argName as AutoRestLanguage) > -1) {
         language = argName as AutoRestLanguage;
       }
     }
+
+    // Override debug flags if --debug was set globally
+    baseCompareOptions = {
+      ...baseCompareOptions,
+      debug: baseCompareOptions.debug || debug
+    };
+    nextCompareOptions = {
+      ...nextCompareOptions,
+      debug: nextCompareOptions.debug || debug
+    };
 
     if (language === undefined) {
       throw new Error(
@@ -85,40 +169,63 @@ Run Arguments
       );
     }
 
-    if (outputPath === undefined) {
+    if (
+      (!baseOutputDetails.useExisting || !nextOutputDetails.useExisting) &&
+      outputPath === undefined
+    ) {
       throw new Error(
         "An output path must be provided with the --output-path parameter."
       );
     }
 
-    if (specPaths.length === 0) {
+    let runs: CompareRun[] = [];
+    if (baseOutputDetails.useExisting && nextOutputDetails.useExisting) {
+      runs.push({
+        baseOutput: baseOutputDetails,
+        nextOutput: nextOutputDetails
+      });
+    } else if (specPaths.length === 0) {
       throw new Error(
         "A spec path must be provided with the --spec-path parameter."
+      );
+    } else {
+      runs = getRunsFromSpecPaths(
+        specPaths,
+        specRootPath,
+        baseOutputDetails || {
+          outputPath: path.resolve(outputPath, "base"),
+          useExisting: false
+        },
+        nextOutputDetails || {
+          outputPath: path.resolve(outputPath, "next"),
+          useExisting: false
+        }
       );
     }
 
     console.log(`*** Comparing output of ${language} generator...`);
 
-    for (const specPath of specPaths) {
-      const fullSpecPath = path.resolve(specRootPath || ".", specPath);
-      if (!path.isAbsolute(outputPath)) {
-        outputPath = path.resolve(outputPath);
+    for (const run of runs) {
+      if (run.fullSpecPath) {
+        console.log("*** Generating code for spec at path:", run.fullSpecPath);
+      } else {
+        console.log(`*** Comparing existing output in paths:
+    ${run.baseOutput.outputPath}
+    ${run.nextOutput.outputPath}`);
       }
-
-      console.log("*** Generating code for spec at path:", fullSpecPath);
 
       // Run two instances of AutoRest simultaneously
       const baseRunPromise = runAutoRest(
         language,
-        fullSpecPath,
-        path.join(outputPath, "base"),
+        run.fullSpecPath || "",
+        run.baseOutput,
         baseCompareOptions
       );
 
       const nextRunPromise = runAutoRest(
         language,
-        fullSpecPath,
-        path.join(outputPath, "next"),
+        run.fullSpecPath || "",
+        run.nextOutput,
         nextCompareOptions
       );
 
@@ -128,19 +235,37 @@ Run Arguments
       ]);
 
       if (baseCompareOptions.debug) {
-        console.log("\nBase AutoRest Output:\n");
-        console.log(baseResult.processOutput);
+        if (baseResult.processOutput) {
+          console.log("\n*** Base AutoRest Output:\n");
+          console.log(baseResult.processOutput);
+        }
+        console.log(`\n*** Output files under ${baseResult.outputPath}:
+${baseResult.outputFiles.map(f => "    " + f).join("\n")}`);
       }
 
       if (nextCompareOptions.debug) {
-        console.log("\nNext AutoRest Output:\n");
-        console.log(nextResult.processOutput);
+        if (nextResult.processOutput) {
+          console.log("\n*** Next AutoRest Output:\n");
+          console.log(nextResult.processOutput);
+        }
+
+        console.log(`\n*** Output files under ${nextResult.outputPath}:
+${nextResult.outputFiles.map(f => "    " + f).join("\n")}`);
       }
 
-      console.log("*** Generation complete, comparing results...");
+      console.log("\n*** Generation complete, comparing results...");
 
-      for (const comparer of getDefaultComparers()) {
-        await comparer(baseResult, nextResult);
+      const compareResult = compareOutputFiles(baseResult, nextResult, {
+        comparersByType: {
+          ts: compareTypeScriptFile
+        }
+      });
+
+      if (compareResult) {
+        console.log(""); // Space out the next section by one line
+        printCompareMessage(compareResult);
+        console.log(""); // Space out the next section by one line
+        process.exit(1);
       }
 
       console.log(
@@ -151,9 +276,6 @@ Run Arguments
 }
 
 main().catch(err => {
-  console.error(
-    "\nAn error occurred while running the validation script:\n\n",
-    err.toString()
-  );
+  console.error("\nAn error occurred during execution:\n\n", err.toString());
   process.exit(1);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ Output Arguments
 Comparison Arguments
 
   --compare-base[:path] [run arguments]        Indicates that what follows are arguments for the base of the comparison.
+
                                                You may also pass a path to an existing folder of output from a previous
                                                AutoRest run: --compare-base:path/to/existing/output.  If a --spec-root-path
                                                is provided, it is expected that the existing output will be located

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,15 +67,15 @@ ${languageArgsString}
 
 Spec Arguments
 
-  --spec-path=[path]                           Use the specified spec path for code generation.  Relative paths will
+  --spec-path:[path]                           Use the specified spec path for code generation.  Relative paths will
                                                be resolved against the value of --spec-root-path if specified.
                                                NOTE: This parameter can be used multiple times to specify more than
                                                one spec path.
-  --spec-root-path=[path]                      The root path from which all spec paths will be resolved.
+  --spec-root-path:[path]                      The root path from which all spec paths will be resolved.
 
 Output Arguments
 
-  --output-path=[generated output path]        The path where generated source files will be omitted.  This should
+  --output-path:[generated output path]        The path where generated source files will be omitted.  This should
                                                generally be under a temporary file path.  When a --spec-root-path
                                                is provided, the path --spec-path relative to the --spec-root-path
                                                will be used as the subpath of the --output-path.

--- a/src/index.ts
+++ b/src/index.ts
@@ -277,6 +277,6 @@ ${nextResult.outputFiles.map(f => "    " + f).join("\n")}`);
 }
 
 main().catch(err => {
-  console.error("\nAn error occurred during execution:\n\n", err.toString());
+  console.error("\nAn error occurred during execution:\n\n", err);
   process.exit(1);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,7 @@ Run Arguments
     while (args.length > 0) {
       const [argName, argValue] = parseArgument(args.shift());
       if (argName === `compare-base`) {
-        if (argValue) {
+        if (argValue && argValue !== "true") {
           baseOutputDetails = {
             outputPath: argValue,
             useExisting: true
@@ -130,7 +130,7 @@ Run Arguments
           [baseCompareOptions, args] = getAutoRestOptionsFromArgs(args);
         }
       } else if (argName === `compare-next`) {
-        if (argValue) {
+        if (argValue && argValue !== "true") {
           nextOutputDetails = {
             outputPath: argValue,
             useExisting: true
@@ -171,7 +171,10 @@ Run Arguments
     }
 
     if (
-      (!baseOutputDetails.useExisting || !nextOutputDetails.useExisting) &&
+      (!baseOutputDetails ||
+        !baseOutputDetails.useExisting ||
+        !nextOutputDetails ||
+        !nextOutputDetails.useExisting) &&
       outputPath === undefined
     ) {
       throw new Error(
@@ -180,7 +183,12 @@ Run Arguments
     }
 
     let runs: CompareRun[] = [];
-    if (baseOutputDetails.useExisting && nextOutputDetails.useExisting) {
+    if (
+      baseOutputDetails &&
+      baseOutputDetails.useExisting &&
+      nextOutputDetails &&
+      nextOutputDetails.useExisting
+    ) {
       runs.push({
         baseOutput: baseOutputDetails,
         nextOutput: nextOutputDetails
@@ -202,6 +210,10 @@ Run Arguments
           useExisting: false
         }
       );
+    }
+
+    if (debug) {
+      console.log("*** Runs to be executed:\n\n", runs, "\n");
     }
 
     console.log(`*** Comparing output of ${language} generator...`);

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -1,0 +1,206 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as Parser from "tree-sitter";
+import * as TypeScript from "tree-sitter-typescript/typescript";
+import { AutoRestResult } from "../runner";
+
+const parser = new Parser();
+parser.setLanguage(TypeScript);
+
+export type ParameterDetails = {
+  name: string;
+  type: string;
+  isOptional: boolean;
+};
+
+export type FieldDetails = {
+  name: string;
+  type: string;
+  value?: string;
+  isPrivate: boolean;
+  isReadOnly?: boolean;
+};
+
+export type MethodDetails = {
+  name: string;
+  returnType: string;
+  parameters: ParameterDetails[];
+};
+
+export type InterfaceDetails = {
+  name: string;
+  interfaces?: string[];
+  methods: MethodDetails[];
+  fields: FieldDetails[];
+  isExported: boolean;
+};
+
+export type ClassDetails = {
+  name: string;
+  baseClass?: string;
+  interfaces?: string[];
+  methods: MethodDetails[];
+  fields: FieldDetails[];
+  isExported: boolean;
+};
+
+export type TypeDetails = {
+  name: string;
+  type: string;
+  isExported: boolean;
+};
+
+export type VariableDetails = {
+  name: string;
+  type: string;
+  value?: string;
+  isExported: boolean;
+};
+
+export type SourceDetails = {
+  classes: ClassDetails[];
+  interfaces: InterfaceDetails[];
+  types: TypeDetails[];
+  variables: VariableDetails[];
+};
+
+export function parseFile(filePath: string): Parser.Tree {
+  const contents = fs.readFileSync(filePath).toString();
+  return parser.parse(contents);
+}
+
+function extractField(fieldNode: Parser.SyntaxNode): FieldDetails {
+  const { typeNode, valueNode } = fieldNode as any;
+  const accessibilityNode = fieldNode.namedChildren.find(
+    n => n.type === "accessibility_modifier"
+  );
+  const readOnlyNode = fieldNode.namedChildren.find(n => n.type === "readonly");
+
+  return {
+    name: (fieldNode as any).nameNode.text,
+    type: typeNode ? typeNode.children[1].text : "any",
+    value: valueNode ? valueNode.text : undefined,
+    isPrivate: accessibilityNode && accessibilityNode.text !== "public",
+    isReadOnly: readOnlyNode !== undefined
+  };
+}
+
+function extractParameter(parameterNode: Parser.SyntaxNode): ParameterDetails {
+  const [nameNode, typeNode] = parameterNode.namedChildren;
+
+  return {
+    name: nameNode.text,
+    isOptional: parameterNode.type === "optional_parameter",
+    type: typeNode ? typeNode.children[1].text : "any"
+  };
+}
+
+function extractMethod(methodNode: Parser.SyntaxNode): MethodDetails {
+  const returnTypeNode = (methodNode as any).returnTypeNode;
+  const parameterNodes = (methodNode as any).parametersNode.namedChildren;
+
+  return {
+    name: (methodNode as any).nameNode.text,
+    returnType: returnTypeNode ? returnTypeNode.children[1].text : "any",
+    parameters: parameterNodes.map(extractParameter)
+  };
+}
+
+function isExported(node: Parser.SyntaxNode): boolean {
+  return node.parent.type === "export_statement";
+}
+
+function extractClass(classNode: Parser.SyntaxNode): ClassDetails {
+  const classBody: Parser.SyntaxNode = (classNode as any).bodyNode;
+  return {
+    name: (classNode as any).nameNode.text,
+    methods: classBody.namedChildren
+      .filter(n => n.type === "method_definition")
+      .map(extractMethod),
+    fields: classBody.namedChildren
+      .filter(n => n.type === "public_field_definition")
+      .map(extractField),
+    isExported: isExported(classNode)
+  };
+}
+
+function extractTypeAlias(typeAliasNode: Parser.SyntaxNode): TypeDetails {
+  const typeNode = (typeAliasNode as any).valueNode;
+
+  return {
+    name: (typeAliasNode as any).nameNode.text,
+    type: typeNode.text,
+    isExported: isExported(typeAliasNode)
+  };
+}
+
+function extractVariable(variableNode: Parser.SyntaxNode): VariableDetails {
+  const typeNode = (variableNode as any).typeNode;
+  const valueNode = (variableNode as any).valueNode;
+
+  return {
+    name: (variableNode as any).nameNode.text,
+    type: typeNode ? typeNode.children[1].text : "any",
+    value: valueNode ? valueNode.text : undefined,
+    // variable_declarator is wrapped in a lexical_declaration
+    isExported: isExported(variableNode.parent)
+  };
+}
+
+export function isModuleScopeVariable(
+  variableNode: Parser.SyntaxNode
+): boolean {
+  const grandparent = variableNode.parent && variableNode.parent.parent;
+  return (
+    grandparent &&
+    (grandparent.type === "export_statement" || grandparent.type === "program")
+  );
+}
+
+export function extractDetails(parseTree: Parser.Tree): SourceDetails {
+  console.error(parseTree.rootNode.toString());
+  return {
+    classes: parseTree.rootNode
+      .descendantsOfType("class_declaration")
+      .map(extractClass),
+    interfaces: [],
+    types: parseTree.rootNode
+      .descendantsOfType("type_alias_declaration")
+      .map(extractTypeAlias),
+    variables: parseTree.rootNode
+      .descendantsOfType("variable_declarator")
+      .filter(isModuleScopeVariable)
+      .map(extractVariable)
+  };
+}
+
+export function buildSourceDetails(
+  sourceFiles: string[],
+  baseSourcePath: string
+): SourceDetails {
+  for (const file of sourceFiles) {
+    const parseTree = parseFile(path.resolve(baseSourcePath, file));
+    extractDetails(parseTree);
+  }
+
+  return {
+    classes: [],
+    interfaces: [],
+    types: [],
+    variables: []
+  };
+}
+
+export async function compareTypeScriptSource(
+  baseResult: AutoRestResult,
+  nextResult: AutoRestResult
+): Promise<void> {
+  const baseSourceDetails = buildSourceDetails(
+    baseResult.outputFiles,
+    baseResult.outputPath
+  );
+  const nextSourceDetails = buildSourceDetails(
+    nextResult.outputFiles,
+    nextResult.outputPath
+  );
+}

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -164,10 +164,6 @@ function isExported(node: Parser.SyntaxNode): boolean {
   return node.parent.type === "export_statement";
 }
 
-function extractImplements(implementsNode: Parser.SyntaxNode): string[] {
-  return implementsNode.namedChildren.map(c => c.text);
-}
-
 function extractImplements(node: Parser.SyntaxNode): string[] {
   const implementsNode: Parser.SyntaxNode = (node as any).namedChildren.find(
     n => n.type === "implements_clause"

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -178,6 +178,20 @@ function extractClass(classNode: Parser.SyntaxNode): ClassDetails {
   };
 }
 
+function extractInterface(interfaceNode: Parser.SyntaxNode): InterfaceDetails {
+  const interfaceBody: Parser.SyntaxNode = (interfaceNode as any).bodyNode;
+  return {
+    name: (interfaceNode as any).nameNode.text,
+    methods: interfaceBody.namedChildren
+      .filter(n => n.type === "method_definition")
+      .map(extractMethod),
+    fields: interfaceBody.namedChildren
+      .filter(n => n.type === "public_field_definition")
+      .map(extractField),
+    isExported: isExported(interfaceNode)
+  };
+}
+
 function extractTypeAlias(typeAliasNode: Parser.SyntaxNode): TypeDetails {
   const typeNode = (typeAliasNode as any).valueNode;
 
@@ -220,7 +234,9 @@ export function extractSourceDetails(parseTree: Parser.Tree): SourceDetails {
     classes: parseTree.rootNode
       .descendantsOfType("class_declaration")
       .map(extractClass),
-    interfaces: [],
+    interfaces: parseTree.rootNode
+      .descendantsOfType("interface_declaration")
+      .map(extractInterface),
     types: parseTree.rootNode
       .descendantsOfType("type_alias_declaration")
       .map(extractTypeAlias),
@@ -238,7 +254,6 @@ export function compareParameter(
   oldParameter: ParameterDetails,
   newParameter: ParameterDetails
 ): CompareResult {
-  newParameter.isOptional;
   return prepareResult(oldParameter.name, MessageType.Changed, [
     compareValue("Type", oldParameter.type, newParameter.type),
     compareValue("Optional", oldParameter.isOptional, newParameter.isOptional)

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1,0 +1,65 @@
+import * as chalk from "chalk";
+import { CompareMessage, MessageType } from "./comparers";
+
+const outputColors = {
+  "-": chalk.redBright,
+  "~": chalk.yellowBright
+};
+
+interface MessageVisual {
+  prefix: string;
+  color: chalk.ChalkFunction;
+}
+
+function getMessageVisual(messageType: MessageType): MessageVisual {
+  let prefix = "•";
+  let color: chalk.ChalkFunction = msg => msg;
+
+  switch (messageType) {
+    case MessageType.Added:
+      prefix = "+";
+      color = chalk.greenBright;
+      break;
+    case MessageType.Removed:
+      prefix = "-";
+      color = chalk.redBright;
+      break;
+    case MessageType.Changed:
+      prefix = "~";
+      color = chalk.yellowBright;
+      break;
+
+    default:
+      // Default already handled
+      break;
+  }
+
+  return {
+    prefix,
+    color
+  };
+}
+
+/**
+ * Prints a CompareMessage and its children in a human-readable way
+ */
+export function printCompareMessage(
+  compareMessage: CompareMessage,
+  indentLevel: number = 0
+): void {
+  const { message, type: messageType, children } = compareMessage;
+  const messageVisual = getMessageVisual(messageType);
+
+  console.log(
+    messageVisual.color(
+      `${"".padEnd(indentLevel * 2)}${messageVisual.prefix} ${message}`
+    )
+  );
+
+  if (children) {
+    const childIndent = indentLevel + 1;
+    children.forEach(child => {
+      printCompareMessage(child, childIndent);
+    });
+  }
+}

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -1,28 +1,29 @@
 import * as chalk from "chalk";
 import { CompareMessage, MessageType } from "./comparers";
 
-const outputColors = {
-  "-": chalk.redBright,
-  "~": chalk.yellowBright
-};
-
 interface MessageVisual {
   prefix: string;
   color: chalk.ChalkFunction;
+  prefixColor: chalk.ChalkFunction;
 }
 
 function getMessageVisual(messageType: MessageType): MessageVisual {
   let prefix = "•";
   let color: chalk.ChalkFunction = msg => msg;
+  let prefixColor: chalk.ChalkFunction | undefined;
 
   switch (messageType) {
     case MessageType.Added:
       prefix = "+";
-      color = chalk.greenBright;
+      color = chalk.green;
       break;
     case MessageType.Removed:
       prefix = "-";
-      color = chalk.redBright;
+      color = chalk.red;
+      break;
+    case MessageType.Outline:
+      color = chalk.underline.whiteBright;
+      prefixColor = chalk.whiteBright;
       break;
     case MessageType.Changed:
       prefix = "~";
@@ -36,7 +37,8 @@ function getMessageVisual(messageType: MessageType): MessageVisual {
 
   return {
     prefix,
-    color
+    color,
+    prefixColor: prefixColor || color
   };
 }
 
@@ -51,9 +53,9 @@ export function printCompareMessage(
   const messageVisual = getMessageVisual(messageType);
 
   console.log(
-    messageVisual.color(
-      `${"".padEnd(indentLevel * 2)}${messageVisual.prefix} ${message}`
-    )
+    `${"".padEnd(indentLevel * 2)}`,
+    messageVisual.prefixColor(messageVisual.prefix),
+    messageVisual.color(message)
   );
 
   if (children) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,19 +5,6 @@ import * as fs from "fs";
 import * as path from "path";
 
 /**
- * Returns a Set containing the items in setA that are not contained within
- * setB.
- */
-export function setDifference(setA: Set<string>, setB: Set<string>): Set<string> {
-  const diff = new Set(setA);
-  for (let item of setB) {
-    diff.delete(item);
-  }
-
-  return diff;
-}
-
-/**
  * Returns a flat list of file paths recursively under the specified folderPath.
  */
 export function getPathsRecursively(folderPath: string): string[] {

--- a/test/artifacts/typescript/base/index.ts
+++ b/test/artifacts/typescript/base/index.ts
@@ -1,0 +1,24 @@
+class SomeClass {
+  private removedField: string;
+  public visibilityChangedField: Namespace.Type;
+  private readonly readOnlyChangedField = "stuff";
+
+  removedMethod(optional?: string): void {}
+  changedParamType(firstParam: string): void {}
+  changedReturnType(firstParam: string): string {
+    const booString = "boo";
+    return booString;
+  }
+  reorderedParams(firstParam: string, secondParam: string): void {}
+}
+
+interface SomeInterface {}
+interface AnotherInterface {}
+class BaseClass {}
+
+export class ExportedClass extends BaseClass
+  implements SomeInterface, AnotherInterface {}
+
+export type SomeUnion = "red" | "green" | "brurple";
+
+export const SomeConst: SomeUnion = "red";

--- a/test/artifacts/typescript/base/index.ts
+++ b/test/artifacts/typescript/base/index.ts
@@ -19,7 +19,8 @@ export function someFunction<T>(genericParam: T): string {
 }
 
 interface SomeInterface {}
-interface AnotherInterface {}
+interface BaseInterface {}
+export interface AnotherInterface extends BaseInterface {}
 class BaseClass {}
 
 export class ExportedClass extends BaseClass

--- a/test/artifacts/typescript/base/index.ts
+++ b/test/artifacts/typescript/base/index.ts
@@ -9,7 +9,13 @@ class SomeClass {
     const booString = "boo";
     return booString;
   }
+
   reorderedParams(firstParam: string, secondParam: string): void {}
+  protected hasGenericParam<T>(genericParam: T): void {}
+}
+
+export function someFunction<T>(genericParam: T): string {
+  return "test";
 }
 
 interface SomeInterface {}

--- a/test/artifacts/typescript/next/index.ts
+++ b/test/artifacts/typescript/next/index.ts
@@ -1,0 +1,17 @@
+class SomeClass {
+  // removedField is removed
+  public visibilityChangedField: Namespace.Type;
+  private readOnlyRemovedField = "stuff";
+
+  // removedMethod is removed
+  changedParamType(firstParam: number): void {}
+  changedReturnType(firstParam: string): number {
+    return 311;
+  }
+}
+
+interface SomeInterface {}
+class DifferentBaseClass {}
+
+export class ExportedClass extends DifferentBaseClass
+  implements SomeInterface {}

--- a/test/artifacts/typescript/next/index.ts
+++ b/test/artifacts/typescript/next/index.ts
@@ -1,7 +1,7 @@
 class SomeClass {
   // removedField is removed
-  public visibilityChangedField: Namespace.Type;
-  private readOnlyRemovedField = "stuff";
+  private visibilityChangedField: Namespace.Type;
+  private readOnlyChangedField = "stuff";
 
   // removedMethod is removed
   changedParamType(firstParam: number): void {}
@@ -9,6 +9,11 @@ class SomeClass {
     return 311;
   }
   reorderedParams(secondParam: string, firstParam: string): void {}
+  hasGenericParam<S>(genericParam: S): void {}
+}
+
+function someFunction(genericParam: number): string {
+  return "test";
 }
 
 interface SomeInterface {}
@@ -16,3 +21,5 @@ class DifferentBaseClass {}
 
 export class ExportedClass extends DifferentBaseClass
   implements SomeInterface {}
+
+let SomeConst: SomeOtherUnion = "blue";

--- a/test/artifacts/typescript/next/index.ts
+++ b/test/artifacts/typescript/next/index.ts
@@ -8,6 +8,7 @@ class SomeClass {
   changedReturnType(firstParam: string): number {
     return 311;
   }
+  reorderedParams(secondParam: string, firstParam: string): void {}
 }
 
 interface SomeInterface {}

--- a/test/languages/typescript.spec.ts
+++ b/test/languages/typescript.spec.ts
@@ -141,7 +141,26 @@ describe("TypeScript Parser", function() {
           isExported: true
         }
       ],
-      interfaces: [],
+      interfaces: [
+        {
+          name: "SomeInterface",
+          methods: [],
+          fields: [],
+          isExported: false
+        },
+        {
+          name: "BaseInterface",
+          methods: [],
+          fields: [],
+          isExported: false
+        },
+        {
+          name: "AnotherInterface",
+          methods: [],
+          fields: [],
+          isExported: true
+        }
+      ],
       types: [
         {
           name: "SomeUnion",

--- a/test/languages/typescript.spec.ts
+++ b/test/languages/typescript.spec.ts
@@ -1,0 +1,127 @@
+import * as assert from "assert";
+import * as path from "path";
+import {
+  parseFile,
+  extractDetails,
+  SourceDetails
+} from "../../src/languages/typescript";
+
+describe("TypeScript Parser", function() {
+  it("extracts classes", function() {
+    const parseTree = parseFile(
+      path.resolve(__dirname, "../artifacts/typescript/base/index.ts")
+    );
+    const sourceDetails: SourceDetails = extractDetails(parseTree);
+
+    assert.deepEqual(sourceDetails, {
+      classes: [
+        {
+          name: "SomeClass",
+          isExported: false,
+          methods: [
+            {
+              name: "removedMethod",
+              returnType: "void",
+              parameters: [
+                {
+                  name: "optional",
+                  type: "string",
+                  isOptional: true
+                }
+              ]
+            },
+            {
+              name: "changedParamType",
+              returnType: "void",
+              parameters: [
+                {
+                  name: "firstParam",
+                  type: "string",
+                  isOptional: false
+                }
+              ]
+            },
+            {
+              name: "changedReturnType",
+              returnType: "string",
+              parameters: [
+                {
+                  name: "firstParam",
+                  type: "string",
+                  isOptional: false
+                }
+              ]
+            },
+            {
+              name: "reorderedParams",
+              returnType: "void",
+              parameters: [
+                {
+                  name: "firstParam",
+                  type: "string",
+                  isOptional: false
+                },
+                {
+                  name: "secondParam",
+                  type: "string",
+                  isOptional: false
+                }
+              ]
+            }
+          ],
+          fields: [
+            {
+              name: "removedField",
+              type: "string",
+              value: undefined,
+              isPrivate: true,
+              isReadOnly: false
+            },
+            {
+              name: "visibilityChangedField",
+              type: "Namespace.Type",
+              value: undefined,
+              isPrivate: false,
+              isReadOnly: false
+            },
+            {
+              name: "readOnlyChangedField",
+              type: "any",
+              value: `"stuff"`,
+              isPrivate: true,
+              isReadOnly: true
+            }
+          ]
+        },
+        {
+          name: "BaseClass",
+          methods: [],
+          fields: [],
+          isExported: false
+        },
+        {
+          name: "ExportedClass",
+          methods: [],
+          fields: [],
+          isExported: true
+        }
+      ],
+      interfaces: [],
+      types: [
+        {
+          name: "SomeUnion",
+          type: `"red" | "green" | "brurple"`,
+          isExported: true
+        }
+      ],
+      variables: [
+        {
+          name: "SomeConst",
+          type: "SomeUnion",
+          value: `"red"`,
+          isExported: true
+        }
+      ]
+    } as SourceDetails);
+  });
+});

--- a/test/languages/typescript.spec.ts
+++ b/test/languages/typescript.spec.ts
@@ -2,16 +2,19 @@ import * as assert from "assert";
 import * as path from "path";
 import {
   parseFile,
-  extractDetails,
-  SourceDetails
+  extractSourceDetails,
+  SourceDetails,
+  compareParameter,
+  compareMethod
 } from "../../src/languages/typescript";
+import { MessageType } from "../../src/comparers";
 
 describe("TypeScript Parser", function() {
   it("extracts classes", function() {
     const parseTree = parseFile(
       path.resolve(__dirname, "../artifacts/typescript/base/index.ts")
     );
-    const sourceDetails: SourceDetails = extractDetails(parseTree);
+    const sourceDetails: SourceDetails = extractSourceDetails(parseTree);
 
     assert.deepEqual(sourceDetails, {
       classes: [
@@ -26,6 +29,7 @@ describe("TypeScript Parser", function() {
                 {
                   name: "optional",
                   type: "string",
+                  ordinal: 0,
                   isOptional: true
                 }
               ]
@@ -37,6 +41,7 @@ describe("TypeScript Parser", function() {
                 {
                   name: "firstParam",
                   type: "string",
+                  ordinal: 0,
                   isOptional: false
                 }
               ]
@@ -48,6 +53,7 @@ describe("TypeScript Parser", function() {
                 {
                   name: "firstParam",
                   type: "string",
+                  ordinal: 0,
                   isOptional: false
                 }
               ]
@@ -59,11 +65,13 @@ describe("TypeScript Parser", function() {
                 {
                   name: "firstParam",
                   type: "string",
+                  ordinal: 0,
                   isOptional: false
                 },
                 {
                   name: "secondParam",
                   type: "string",
+                  ordinal: 1,
                   isOptional: false
                 }
               ]
@@ -123,5 +131,97 @@ describe("TypeScript Parser", function() {
         }
       ]
     } as SourceDetails);
+  });
+
+  it("compares parameters", () => {
+    const result = compareParameter(
+      {
+        name: "firstParam",
+        type: "string",
+        ordinal: 0,
+        isOptional: false
+      },
+      {
+        name: "firstParam",
+        type: "number",
+        ordinal: 0,
+        isOptional: true
+      }
+    );
+
+    assert.deepEqual(result, {
+      message: "firstParam",
+      type: MessageType.Changed,
+      children: [
+        {
+          message: "Type",
+          type: MessageType.Outline,
+          children: [
+            { message: "string", type: MessageType.Removed },
+            { message: "number", type: MessageType.Added }
+          ]
+        },
+        {
+          message: "Optional",
+          type: MessageType.Outline,
+          children: [
+            { message: "false", type: MessageType.Removed },
+            { message: "true", type: MessageType.Added }
+          ]
+        }
+      ]
+    });
+  });
+
+  it("compares methods", () => {
+    const result = compareMethod(
+      {
+        name: "theFunc",
+        returnType: "string",
+        parameters: [
+          {
+            name: "firstParam",
+            type: "string",
+            ordinal: 0,
+            isOptional: false
+          }
+        ]
+      },
+      {
+        name: "theFunc",
+        returnType: "any",
+        parameters: [
+          {
+            name: "differentParam",
+            type: "number",
+            ordinal: 0,
+            isOptional: true
+          }
+        ]
+      }
+    );
+
+    assert.deepEqual(result, {
+      message: "theFunc",
+      type: MessageType.Changed,
+      children: [
+        {
+          message: "Parameters",
+          type: MessageType.Outline,
+          children: [
+            { message: "firstParam", type: MessageType.Removed },
+            { message: "differentParam", type: MessageType.Added }
+          ]
+        },
+        {
+          message: "Return Type",
+          type: MessageType.Outline,
+          children: [
+            { message: "string", type: MessageType.Removed },
+            { message: "any", type: MessageType.Added }
+          ]
+        }
+      ]
+    });
   });
 });

--- a/test/languages/typescript.spec.ts
+++ b/test/languages/typescript.spec.ts
@@ -25,6 +25,8 @@ describe("TypeScript Parser", function() {
             {
               name: "removedMethod",
               returnType: "void",
+              visibility: "public",
+              genericTypes: [],
               parameters: [
                 {
                   name: "optional",
@@ -37,6 +39,8 @@ describe("TypeScript Parser", function() {
             {
               name: "changedParamType",
               returnType: "void",
+              visibility: "public",
+              genericTypes: [],
               parameters: [
                 {
                   name: "firstParam",
@@ -49,6 +53,8 @@ describe("TypeScript Parser", function() {
             {
               name: "changedReturnType",
               returnType: "string",
+              visibility: "public",
+              genericTypes: [],
               parameters: [
                 {
                   name: "firstParam",
@@ -61,6 +67,8 @@ describe("TypeScript Parser", function() {
             {
               name: "reorderedParams",
               returnType: "void",
+              visibility: "public",
+              genericTypes: [],
               parameters: [
                 {
                   name: "firstParam",
@@ -75,6 +83,25 @@ describe("TypeScript Parser", function() {
                   isOptional: false
                 }
               ]
+            },
+            {
+              name: "hasGenericParam",
+              visibility: "protected",
+              returnType: "void",
+              genericTypes: [
+                {
+                  name: "T",
+                  ordinal: 0
+                }
+              ],
+              parameters: [
+                {
+                  name: "genericParam",
+                  isOptional: false,
+                  ordinal: 0,
+                  type: "T"
+                }
+              ]
             }
           ],
           fields: [
@@ -82,22 +109,22 @@ describe("TypeScript Parser", function() {
               name: "removedField",
               type: "string",
               value: undefined,
-              isPrivate: true,
-              isReadOnly: false
+              isReadOnly: false,
+              visibility: "private"
             },
             {
               name: "visibilityChangedField",
               type: "Namespace.Type",
               value: undefined,
-              isPrivate: false,
-              isReadOnly: false
+              isReadOnly: false,
+              visibility: "public"
             },
             {
               name: "readOnlyChangedField",
               type: "any",
               value: `"stuff"`,
-              isPrivate: true,
-              isReadOnly: true
+              isReadOnly: true,
+              visibility: "private"
             }
           ]
         },
@@ -122,12 +149,33 @@ describe("TypeScript Parser", function() {
           isExported: true
         }
       ],
+      functions: [
+        {
+          genericTypes: [
+            {
+              name: "T",
+              ordinal: 0
+            }
+          ],
+          name: "someFunction",
+          parameters: [
+            {
+              name: "genericParam",
+              type: "T",
+              ordinal: 0,
+              isOptional: false
+            }
+          ],
+          returnType: "string"
+        }
+      ],
       variables: [
         {
           name: "SomeConst",
           type: "SomeUnion",
           value: `"red"`,
-          isExported: true
+          isExported: true,
+          isConst: true
         }
       ]
     } as SourceDetails);
@@ -178,6 +226,7 @@ describe("TypeScript Parser", function() {
       {
         name: "theFunc",
         returnType: "string",
+        genericTypes: [],
         parameters: [
           {
             name: "firstParam",
@@ -190,6 +239,7 @@ describe("TypeScript Parser", function() {
       {
         name: "theFunc",
         returnType: "any",
+        genericTypes: [],
         parameters: [
           {
             name: "differentParam",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,8 @@
   },
   "exclude": [
     "dist",
-    "node_modules"
+    "node_modules",
+    "generated/**",
+    "test/**"
   ]
 }


### PR DESCRIPTION
This change leverages [`node-tree-sitter`](https://github.com/tree-sitter/node-tree-sitter) to implement high-level extraction of TypeScript semantic elements so that they can be compared for meaningful changes.  The kind of changes the code looks for:

- Added or removed classes, methods, functions
- Type signature changes
- Variable and constant value changes
- Reordered method parameters

I've developed a framework for language comparison that should make it pretty easy to add other languages since all those we care about offer Tree Sitter parsers.

Here's a screenshot of the output of `autorest-compare` when run against the files I've added in `test/artifacts/typescript/base` and `test/artifacts/typescript/next`:

![typescript_diff](https://user-images.githubusercontent.com/79405/70949084-c9c6c000-2011-11ea-9068-6cd4f44ae8ca.png)

**Tasks**

- [x] Add comparison for top-level variables
- [x] Add comparison for top-level functions
- [x] Add comparison for class and interface extends/implements references
- [x] Add extra tests for parsing and comparisons
- [x] Add documentation comments for all exported methods, especially in `comparer.ts`