### PR TITLE
Perform a text diff of function bodies and variable values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,11 @@
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
+    "@types/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-mIenTfsIe586/yzsyfql69KRnA75S8SVXQbTLpDejRrjH0QSJcpu3AUOi/Vjnt9IOsXKxPhJfGpQUNMueIU1fQ=="
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -318,8 +323,7 @@
     "diff": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
-      "dev": true
+      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
     },
     "emoji-regex": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   "homepage": "https://github.com/Azure/autorest.compare#readme",
   "dependencies": {
     "@autorest/autorest": "^3.0.6149",
+    "@types/diff": "^4.0.2",
     "chalk": "^3.0.0",
+    "diff": "^4.0.1",
     "tree-sitter": "^0.16.0",
     "tree-sitter-typescript": "^0.16.1"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,7 +28,8 @@ export function getAutoRestOptionsFromArgs(
   args: string[]
 ): [AutoRestOptions, string[]] {
   const options: AutoRestOptions = {
-    useArgs: []
+    useArgs: [],
+    miscArgs: []
   };
 
   while (args.length > 0) {
@@ -44,6 +45,8 @@ export function getAutoRestOptionsFromArgs(
       options.useArgs.push(argValue);
     } else if (argName === "debug") {
       options.debug = argValue === "true";
+    } else {
+      options.miscArgs.push(arg);
     }
   }
 

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -10,7 +10,8 @@ import {
   compareValue,
   MessageType,
   OrderedItem,
-  compareStrings
+  compareStrings,
+  compareText
 } from "../comparers";
 
 const parser = new Parser();
@@ -43,6 +44,7 @@ export interface GenericTypeParameterDetails extends OrderedItem {}
 
 export interface FunctionDetails {
   name: string;
+  body: string;
   returnType: string;
   genericTypes: GenericTypeParameterDetails[];
   parameters: ParameterDetails[];
@@ -139,6 +141,7 @@ function extractFunction(functionNode: Parser.SyntaxNode): FunctionDetails {
 
   return {
     name: (functionNode as any).nameNode.text,
+    body: (functionNode as any).bodyNode.text,
     genericTypes: genericNodes
       ? genericNodes.namedChildren.map((p, i) => extractGenericParameter(p, i))
       : [],
@@ -314,7 +317,8 @@ export function compareFunction(
       true
     ),
     compareValue("Return Type", oldFunction.returnType, newFunction.returnType),
-    ...(extraResults || [])
+    ...(extraResults || []),
+    compareText("Body", oldFunction.body, newFunction.body)
   ]);
 }
 
@@ -333,7 +337,7 @@ export function compareField(
 ): CompareResult {
   return prepareResult(oldField.name, MessageType.Changed, [
     compareValue("Type", oldField.type, newField.type),
-    compareValue("Value", oldField.value, newField.value),
+    compareText("Value", oldField.value, newField.value),
     compareValue("Visibility", oldField.visibility, newField.visibility),
     compareValue("Read Only", oldField.isReadOnly, newField.isReadOnly)
   ]);
@@ -345,7 +349,7 @@ export function compareVariable(
 ): CompareResult {
   return prepareResult(oldVariable.name, MessageType.Changed, [
     compareValue("Type", oldVariable.type, newVariable.type),
-    compareValue("Value", oldVariable.value, newVariable.value),
+    compareText("Value", oldVariable.value, newVariable.value),
     compareValue("Exported", oldVariable.isExported, newVariable.isExported),
     compareValue("Constant", oldVariable.isConst, newVariable.isConst)
   ]);

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -25,11 +25,14 @@ function getMessageVisual(messageType: MessageType): MessageVisual {
       color = chalk.underline.whiteBright;
       prefixColor = chalk.whiteBright;
       break;
+    case MessageType.Plain:
+      prefix = " ";
+      color = chalk.whiteBright;
+      break;
     case MessageType.Changed:
       prefix = "~";
       color = chalk.yellowBright;
       break;
-
     default:
       // Default already handled
       break;
@@ -51,12 +54,15 @@ export function printCompareMessage(
 ): void {
   const { message, type: messageType, children } = compareMessage;
   const messageVisual = getMessageVisual(messageType);
+  const messageLines = message.trimRight().split("\n");
 
-  console.log(
-    `${"".padEnd(indentLevel * 2)}`,
-    messageVisual.prefixColor(messageVisual.prefix),
-    messageVisual.color(message)
-  );
+  messageLines.forEach(line => {
+    console.log(
+      `${"".padEnd(indentLevel * 2)}`,
+      messageVisual.prefixColor(messageVisual.prefix),
+      messageVisual.color(line)
+    );
+  });
 
   if (children) {
     const childIndent = indentLevel + 1;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -18,6 +18,7 @@ export interface OutputDetails {
  */
 export interface AutoRestOptions {
   useArgs?: string[];
+  miscArgs?: string[];
   version?: string;
   debug?: boolean;
 }
@@ -114,7 +115,10 @@ async function spawnAutoRest(
       `--${language}.clear-output-folder`,
 
       // The path to the input spec
-      specPath,
+      path.extname(specPath) !== "" ? `--input-file="${specPath}"` : specPath,
+
+      // Any additional arguments
+      ...(options.miscArgs || []),
 
       // The --debug flag, if requested
       ...(options.debug ? ["--debug"] : [])
@@ -146,16 +150,16 @@ async function spawnAutoRest(
             }) exited with non-zero code:\n\n${errorOutput || normalOutput}`
           )
         );
+      } else {
+        const timeElapsed = Date.now() - startTime;
+
+        resolve({
+          ...getBaseResult(outputPath),
+          version: options.version,
+          processOutput: normalOutput,
+          timeElapsed
+        });
       }
-
-      const timeElapsed = Date.now() - startTime;
-
-      resolve({
-        ...getBaseResult(outputPath),
-        version: options.version,
-        processOutput: normalOutput,
-        timeElapsed
-      });
     });
   });
 }

--- a/test/artifacts/typescript/base/index.ts
+++ b/test/artifacts/typescript/base/index.ts
@@ -21,8 +21,8 @@ export function someFunction<T>(genericParam: T): string {
 interface SomeInterface {}
 interface BaseInterface {}
 export interface AnotherInterface extends BaseInterface {}
-class BaseClass {}
 
+class BaseClass {}
 export class ExportedClass extends BaseClass
   implements SomeInterface, AnotherInterface {}
 


### PR DESCRIPTION
This change uses the `diff` library to perform a line-based text diff of function/method bodies and variable values so that we can catch changes to operation implementations and mapper definitions in generated TypeScript code.  This is a cheap way to get a reading on whether these things have changed without having to write a complete source tree walker :sweat_smile: 

Here's an example of the output when comparing AutoRest v2 versus v3 with the Redis resource manager spec (with a contrived function body change thrown in):

```
 • Generated Output Files
   + code-model-v1
   ~ src/models/mappers.ts
     • Variables
       ~ RedisCreateParameters
         • Value
             {
               serializedName: "RedisCreateParameters",
               type: {
                 name: "Composite",
                 className: "RedisCreateParameters",
             ... [trimmed for brevity] ...
           -         constraints: {
           -           Pattern: /^\/subscriptions\/[^\/]*\/resourceGroups\/[^\/]*\/providers\/Microsoft.(ClassicNetwork|Network)\/virtualNetworks\/[^\/]*\/subnets\/[^\/]*$/
           -         },
                     type: {
                       name: "String"
                     }
                   },
                   staticIP: {
             ... [trimmed for brevity] ...
           -         constraints: {
           -           Pattern: /^\d+\.\d+\.\d+\.\d+$/
           -         },
                     type: {
                       name: "String"
                     }
                   },
                   zones: {
             ... [trimmed for brevity] ...
       ~ RedisResource
         • Value
             {
               serializedName: "RedisResource",
               type: {
                 name: "Composite",
                 className: "RedisResource",
             ... [trimmed for brevity] ...
           -         constraints: {
           -           Pattern: /^\/subscriptions\/[^\/]*\/resourceGroups\/[^\/]*\/providers\/Microsoft.(ClassicNetwork|Network)\/virtualNetworks\/[^\/]*\/subnets\/[^\/]*$/
           -         },
                     type: {
                       name: "String"
                     }
                   },
                   staticIP: {
             ... [trimmed for brevity] ...
           -         constraints: {
           -           Pattern: /^\d+\.\d+\.\d+\.\d+$/
           -         },
                     type: {
                       name: "String"
                     }
                   },
                   redisVersion: {
             ... [trimmed for brevity] ...
       ~ OperationDisplay
         • Value
             {
           -   serializedName: "Operation_display",
           +   serializedName: "Operation-display",
               type: {
                 name: "Composite",
                 className: "OperationDisplay",
                 modelProperties: {
                   provider: {
             ... [trimmed for brevity] ...
   ~ src/models/parameters.ts
     • Variables
       ~ apiVersion
         • Value
             {
               parameterPath: "apiVersion",
               mapper: {
                 required: true,
           +     isConstant: true,
                 serializedName: "api-version",
           +     defaultValue: '2019-07-01-preview',
                 type: {
                   name: "String"
                 }
               }
             }
   ~ src/operations/linkedServer.ts
     • Classes
       ~ LinkedServer
         • Methods
           ~ create
             • Body
                 {
               -     return this.beginCreate(resourceGroupName,name,linkedServerName,parameters,options)
               +     // Something changed!
               +     return this.beginCreate(resourceGroupName,linkedServerName,parameters,options)
                       .then(lroPoller => lroPoller.pollUntilFinished()) as Promise<Models.LinkedServerCreateResponse>;
                   }
```