### PR TITLE
Add support for YAML-based run configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,23 +71,23 @@ wish to use.  Specific usage scenarios are described in the following sections.
 * Comparing the Python output between two versions of `@autorest/modelerfour`:
 
   ```shell
-  autorest-compare --python --spec-path path/to/spec.json \
+  autorest-compare --compare --language:python --spec-path path/to/spec.json \
     --output-path path/to/output \
-    --compare-old --use:@autorest/modelerfour@4.1.59 \
-    --compare-new --use:@autorest/modelerfour@4.1.60
+    --old-args --use:@autorest/modelerfour@4.1.59 \
+    --new-args --use:@autorest/modelerfour@4.1.60
   ```
 
 * Comparing the TypeScript output of generating a set of specs in the
   `azure-rest-api-specs` repository between AutoRest v2 and AutoRest v3:
 
   ```shell
-  autorest-compare --typescript \
+  autorest-compare --compare --language:typescript \
     --spec-root-path:../path/to/azure-rest-api-specs/specifications \
     --spec-path:redis/resource-manager \
     --spec-path:keyvault/resource-manager \
     --output-path path/to/output \
-    --compare-old --version:^2.0.0 \
-    --compare-new --version:3.0.6179
+    --old-args --version:^2.0.0 \
+    --new-args --version:3.0.6179
   ```
 
   Note that the `--spec-path` parameter can be passed multiple times to include

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,11 @@
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-mIenTfsIe586/yzsyfql69KRnA75S8SVXQbTLpDejRrjH0QSJcpu3AUOi/Vjnt9IOsXKxPhJfGpQUNMueIU1fQ=="
     },
+    "@types/js-yaml": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.2.tgz",
+      "integrity": "sha512-0CFu/g4mDSNkodVwWijdlr8jH7RoplRWNgovjFLEZeT+QEbbZXjBmCe3HwaWheAlCbHwomTwzZoSedeOycABug=="
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -81,7 +86,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -376,8 +380,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "expand-template": {
       "version": "2.0.3",
@@ -606,7 +609,6 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -1029,8 +1031,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "string-width": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/compare",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Compares the output between two AutoRest runs to check for material differences.",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "ts-node src/index.ts",
     "test:unit": "ts-mocha -p tsconfig.json test/**/*.spec.ts",
     "test-run": "ts-node src/index.ts --typescript --spec-path:redis/resource-manager --spec-root-path:../azure-rest-api-specs/specification --output-path:generated/ --compare-base --version:^2.0.0 --compare-next --version:3.0.6170",
+    "test-generate": "ts-node src/index.ts --generate-baseline --typescript --spec-path:redis/resource-manager --spec-root-path:../azure-rest-api-specs/specification --output-path:generated/ --compare-base --version:^2.0.0 --compare-next --version:3.0.6170",
     "build": "tsc -p ."
   },
   "repository": {
@@ -25,8 +26,10 @@
   "dependencies": {
     "@autorest/autorest": "https://github.com/Azure/autorest/releases/download/autorest-3.0.6165/autorest-autorest-3.0.6165.tgz",
     "@types/diff": "^4.0.2",
+    "@types/js-yaml": "^3.12.2",
     "chalk": "^3.0.0",
     "diff": "^4.0.1",
+    "js-yaml": "^3.13.1",
     "tree-sitter": "^0.16.0",
     "tree-sitter-typescript": "^0.16.1"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -93,12 +93,14 @@ function getCompareConfiguration(args: string[]): RunConfiguration {
   while (args.length > 0) {
     const [argName, argValue] = parseArgument(args.shift());
     if (argName === "compare") {
-      if (!fs.existsSync(argValue)) {
-        throw new Error(`Configuration file does not exist: ${argValue}`);
-      }
+      if (argValue !== "true") {
+        if (!fs.existsSync(argValue)) {
+          throw new Error(`Configuration file does not exist: ${argValue}`);
+        }
 
-      configPath = argValue;
-      runConfig = loadConfiguration(configPath);
+        configPath = argValue;
+        runConfig = loadConfiguration(configPath);
+      }
     } else if (argName === "old-args") {
       if (!warnIfConfigFileUsed("old-args")) {
         [languageConfig.oldArgs, args] = getAutoRestArgs(args);
@@ -207,6 +209,12 @@ function getBaselineConfiguration(args: string[]): RunConfiguration {
     const arg = args.shift();
     const [argName, argValue] = parseArgument(arg);
     if (argName === "generate-baseline") {
+      if (argValue === "true") {
+        throw new Error(
+          "A configuration file must be specified: --generate-baseline:path-to-config.yaml"
+        );
+      }
+
       if (!fs.existsSync(argValue)) {
         throw new Error(`Configuration file does not exist: ${argValue}`);
       }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { AutoRestOptions } from "./runner";
+import * as path from "path";
+import { AutoRestLanguages, AutoRestLanguage } from "./runner";
+import {
+  RunConfiguration,
+  loadConfiguration,
+  SpecConfiguration,
+  LanguageConfiguration
+} from "./config";
+import { CompareOperation, BaselineOperation, Operation } from "./operations";
 
 /**
  * Parses an argument of one of the following forms and returns the argument and
@@ -21,34 +29,167 @@ export function parseArgument(argument: string): [string, string] {
 }
 
 /**
- * Builds an AutoRestOptions instance from the arguments contained in the args
- * array, stopping when an argument may indicate a different option set.
+ * Returns a tuple of the AutoRest args and any remaining arguments at the point
+ * where a boundary argument (--old-args or --new-args) is encountered.
  */
-export function getAutoRestOptionsFromArgs(
-  args: string[]
-): [AutoRestOptions, string[]] {
-  const options: AutoRestOptions = {
-    useArgs: [],
-    miscArgs: []
+export function getAutoRestArgs(args: string[]): [string[], string[]] {
+  const autoRestArgs = [];
+
+  while (args.length > 0) {
+    const arg = args.shift();
+    const [argName, _] = parseArgument(arg);
+
+    if (argName === "old-args" || argName === "new-args") {
+      args.unshift(arg);
+      break;
+    } else {
+      autoRestArgs.push(arg);
+    }
+  }
+
+  return [autoRestArgs, args];
+}
+
+function getCompareConfiguration(args: string[]): RunConfiguration {
+  let languageConfig: LanguageConfiguration = {
+    language: undefined,
+    outputPath: undefined,
+    oldArgs: [],
+    newArgs: []
   };
+
+  let specConfig: SpecConfiguration = {
+    specRootPath: undefined,
+    specPaths: []
+  };
+
+  let compareConfig: RunConfiguration = {
+    debug: false,
+    specs: [specConfig],
+    languages: [languageConfig]
+  };
+
+  while (args.length > 0) {
+    const [argName, argValue] = parseArgument(args.shift());
+    if (argName === `old-args`) {
+      [languageConfig.oldArgs, args] = getAutoRestArgs(args);
+    } else if (argName === `new-args`) {
+      [languageConfig.newArgs, args] = getAutoRestArgs(args);
+    } else if (argName === `spec-path`) {
+      specConfig.specPaths.push(argValue);
+    } else if (argName === `spec-root-path`) {
+      specConfig.specRootPath = argValue;
+    } else if (argName === `output-path`) {
+      languageConfig.outputPath = argValue;
+    } else if (argName === `use-existing-output`) {
+      if (argValue === "old" || argValue === "all" || argValue === "none") {
+        languageConfig.useExistingOutput = argValue;
+      } else {
+        throw new Error(
+          `Unexpected value for --use-existing-output: ${argValue}`
+        );
+      }
+    } else if (argName === "debug") {
+      compareConfig.debug = argValue === "true";
+    } else if (AutoRestLanguages.indexOf(argName as AutoRestLanguage) > -1) {
+      languageConfig.language = argName as AutoRestLanguage;
+    }
+  }
+
+  // Add debug flags if --debug was set globally
+  if (compareConfig.debug) {
+    languageConfig.oldArgs.push("--debug");
+    languageConfig.newArgs.push("--debug");
+  }
+
+  if (languageConfig.language === undefined) {
+    throw new Error(
+      `Missing language parameter.  Please use one of the following:\n${[
+        "",
+        ...AutoRestLanguages
+      ].join("\n    --")}\n`
+    );
+  }
+
+  if (languageConfig.outputPath === undefined) {
+    throw new Error(
+      "An output path must be provided with the --output-path parameter."
+    );
+  }
+
+  if (specConfig.specPaths.length === 0) {
+    throw new Error(
+      "A spec path must be provided with the --spec-path parameter."
+    );
+  }
+
+  return compareConfig;
+}
+
+function getBaselineConfiguration(args: string[]): RunConfiguration {
+  let configPath: string;
+  let compareConfig: RunConfiguration;
+  let languageToRun: string;
 
   while (args.length > 0) {
     const arg = args.shift();
     const [argName, argValue] = parseArgument(arg);
-
-    if (argName === "compare-old" || argName === "compare-new") {
-      args.unshift(arg);
-      break;
-    } else if (argName === "version") {
-      options.version = argValue;
-    } else if (argName === "use") {
-      options.useArgs.push(argValue);
-    } else if (argName === "debug") {
-      options.debug = argValue === "true";
+    if (argName === "generate-baseline") {
+      // TODO: Error when no path given
+      configPath = argValue;
+      compareConfig = loadConfiguration(configPath);
+    } else if (argName === "language") {
+      languageToRun = argValue;
     } else {
-      options.miscArgs.push(arg);
+      throw Error(`Unexpected argument: ${arg}`);
     }
   }
 
-  return [options, args];
+  // Resolve paths relative to configuration file
+  const fullConfigPath = path.dirname(path.resolve(configPath));
+  compareConfig = {
+    ...compareConfig,
+    specs: compareConfig.specs.map(resolveSpecRootPath(fullConfigPath)),
+    languages: compareConfig.languages.map(resolveOutputPath(fullConfigPath))
+  };
+
+  // Filter language configurations to desired language
+  if (languageToRun) {
+    compareConfig.languages = [
+      compareConfig.languages.find(l => l.language === languageToRun)
+    ];
+    // TODO: Throw if empty
+  }
+
+  return compareConfig;
+}
+
+function resolveSpecRootPath(configPath: string) {
+  return function(specConfig: SpecConfiguration): SpecConfiguration {
+    return {
+      ...specConfig,
+      specRootPath: path.resolve(configPath, specConfig.specRootPath)
+    };
+  };
+}
+
+function resolveOutputPath(configPath: string) {
+  return function(
+    languageConfig: LanguageConfiguration
+  ): LanguageConfiguration {
+    return {
+      ...languageConfig,
+      outputPath: path.resolve(configPath, languageConfig.outputPath)
+    };
+  };
+}
+
+export function getOperationFromArgs(
+  args: string[]
+): [Operation, RunConfiguration] {
+  if (args[0].startsWith("--compare")) {
+    return [new CompareOperation(), getCompareConfiguration(args)];
+  } else if (args[0].startsWith("--generate-baseline")) {
+    return [new BaselineOperation(), getBaselineConfiguration(args)];
+  }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,58 +92,77 @@ function getCompareConfiguration(args: string[]): RunConfiguration {
 
   while (args.length > 0) {
     const [argName, argValue] = parseArgument(args.shift());
-    if (argName === "compare") {
-      if (argValue !== "true") {
-        if (!fs.existsSync(argValue)) {
-          throw new Error(`Configuration file does not exist: ${argValue}`);
-        }
 
-        configPath = argValue;
-        runConfig = loadConfiguration(configPath);
-      }
-    } else if (argName === "old-args") {
-      if (!warnIfConfigFileUsed("old-args")) {
-        [languageConfig.oldArgs, args] = getAutoRestArgs(args);
-      }
-    } else if (argName === "new-args") {
-      if (!warnIfConfigFileUsed("new-args")) {
-        [languageConfig.newArgs, args] = getAutoRestArgs(args);
-      }
-    } else if (argName === "spec-path") {
-      if (!warnIfConfigFileUsed("spec-path")) {
-        specConfig.specPaths.push(argValue);
-      }
-    } else if (argName === "spec-root-path") {
-      if (!warnIfConfigFileUsed("spec-root-path")) {
-        specConfig.specRootPath = argValue;
-      }
-    } else if (argName === "output-path") {
-      if (!warnIfConfigFileUsed("output-path")) {
-        languageConfig.outputPath = argValue;
-      }
-    } else if (argName === "use-existing-output") {
-      if (argValue === "old" || argValue === "all" || argValue === "none") {
-        useExistingOutput = argValue;
-      } else {
-        throw new Error(
-          `Unexpected value for --use-existing-output: ${argValue}`
-        );
-      }
-    } else if (argName === "language") {
-      if (AutoRestLanguages.indexOf(argValue as AutoRestLanguage) > -1) {
-        languageToRun = argValue as AutoRestLanguage;
-        if (configPath === undefined) {
-          languageConfig.language = languageToRun;
+    switch (argName) {
+      case "compare":
+        if (argValue !== "true") {
+          if (!fs.existsSync(argValue)) {
+            throw new Error(`Configuration file does not exist: ${argValue}`);
+          }
+
+          configPath = argValue;
+          runConfig = loadConfiguration(configPath);
         }
-      } else {
-        throw new Error(
-          `Unexpected value for --language: ${argValue}.  Supported languages are: ${AutoRestLanguages.join(
-            ", "
-          )}.`
-        );
-      }
-    } else if (argName === "debug") {
-      runConfig.debug = argValue === "true";
+        break;
+
+      case "old-args":
+        if (!warnIfConfigFileUsed("old-args")) {
+          [languageConfig.oldArgs, args] = getAutoRestArgs(args);
+        }
+        break;
+
+      case "new-args":
+        if (!warnIfConfigFileUsed("new-args")) {
+          [languageConfig.newArgs, args] = getAutoRestArgs(args);
+        }
+        break;
+
+      case "spec-path":
+        if (!warnIfConfigFileUsed("spec-path")) {
+          specConfig.specPaths.push(argValue);
+        }
+        break;
+
+      case "spec-root-path":
+        if (!warnIfConfigFileUsed("spec-root-path")) {
+          specConfig.specRootPath = argValue;
+        }
+        break;
+
+      case "output-path":
+        if (!warnIfConfigFileUsed("output-path")) {
+          languageConfig.outputPath = argValue;
+        }
+        break;
+
+      case "use-existing-output":
+        if (argValue === "old" || argValue === "all" || argValue === "none") {
+          useExistingOutput = argValue;
+        } else {
+          throw new Error(
+            `Unexpected value for --use-existing-output: ${argValue}`
+          );
+        }
+        break;
+
+      case "language":
+        if (AutoRestLanguages.indexOf(argValue as AutoRestLanguage) > -1) {
+          languageToRun = argValue as AutoRestLanguage;
+          if (configPath === undefined) {
+            languageConfig.language = languageToRun;
+          }
+        } else {
+          throw new Error(
+            `Unexpected value for --language: ${argValue}.  Supported languages are: ${AutoRestLanguages.join(
+              ", "
+            )}.`
+          );
+        }
+        break;
+
+      case "debug":
+        runConfig.debug = argValue === "true";
+        break;
     }
   }
 
@@ -208,31 +227,37 @@ function getBaselineConfiguration(args: string[]): RunConfiguration {
   while (args.length > 0) {
     const arg = args.shift();
     const [argName, argValue] = parseArgument(arg);
-    if (argName === "generate-baseline") {
-      if (argValue === "true") {
-        throw new Error(
-          "A configuration file must be specified: --generate-baseline:path-to-config.yaml"
-        );
-      }
 
-      if (!fs.existsSync(argValue)) {
-        throw new Error(`Configuration file does not exist: ${argValue}`);
-      }
+    switch (argName) {
+      case "generate-baseline":
+        if (argValue === "true") {
+          throw new Error(
+            "A configuration file must be specified: --generate-baseline:path-to-config.yaml"
+          );
+        }
 
-      configPath = argValue;
-      runConfig = loadConfiguration(configPath);
-    } else if (argName === "language") {
-      if (AutoRestLanguages.indexOf(argValue as AutoRestLanguage) > -1) {
-        languageToRun = argValue as AutoRestLanguage;
-      } else {
-        throw new Error(
-          `Unexpected value for --language: ${argValue}.  Supported languages are: ${AutoRestLanguages.join(
-            ", "
-          )}.`
-        );
-      }
-    } else {
-      throw Error(`Unexpected argument: ${arg}`);
+        if (!fs.existsSync(argValue)) {
+          throw new Error(`Configuration file does not exist: ${argValue}`);
+        }
+
+        configPath = argValue;
+        runConfig = loadConfiguration(configPath);
+        break;
+
+      case "language":
+        if (AutoRestLanguages.indexOf(argValue as AutoRestLanguage) > -1) {
+          languageToRun = argValue as AutoRestLanguage;
+        } else {
+          throw new Error(
+            `Unexpected value for --language: ${argValue}.  Supported languages are: ${AutoRestLanguages.join(
+              ", "
+            )}.`
+          );
+        }
+        break;
+
+      default:
+        throw Error(`Unexpected argument: ${arg}`);
     }
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,7 +61,7 @@ function getCompareConfiguration(args: string[]): RunConfiguration {
   function warnIfConfigFileUsed(argName: string): boolean {
     if (configPath !== undefined) {
       console.log(
-        chalk.white(
+        chalk.gray(
           `Skipping argument '${argName}' and using value from ${configPath}`
         )
       );

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,8 @@ export interface SpecConfiguration {
   specPaths: string[];
 }
 
+export type UseExistingOutput = "none" | "old" | "all";
+
 /**
  * Defines configuration for runs of a particular language generator.
  */
@@ -58,11 +60,11 @@ export interface LanguageConfiguration {
 
   /**
    * Determines whether existing output for the baseline should be used.
-   * Defaults to "old" (baseline). "all" will cause existing output to be
-   * used for old and new runs, "none" will force old and new output to be
-   * regenerated.
+   * Defaults to "none" which forces old and new output to be regenerated.
+   * "all" will cause existing output to be used for old and new runs, "old"
+   * reuse the existing old (baseline) output.
    */
-  useExistingOutput?: "none" | "old" | "all";
+  useExistingOutput?: UseExistingOutput;
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as fs from "fs";
+import * as yaml from "js-yaml";
+import { AutoRestLanguage } from "./runner";
+
+/**
+ * Defines configuration for a set of specs with a root path.
+ */
+export interface SpecConfiguration {
+  /**
+   * The root path from which the following spec paths can be found.  If this is
+   * a relative path it will be resolved relative to the path where the
+   * configuration file was found.
+   */
+  specRootPath: string;
+
+  /**
+   * The array of relative spec paths to be generated for each language.
+   */
+  specPaths: string[];
+}
+
+/**
+ * Defines configuration for runs of a particular language generator.
+ */
+export interface LanguageConfiguration {
+  /**
+   * The name of the language of the generated code.
+   */
+  language: AutoRestLanguage;
+
+  /**
+   * The base output path for the output of this language.  If this is a relative path
+   * it will be resolved relative to the path where the configuration file was found.
+   */
+  outputPath: string;
+
+  /**
+   * The array of arguments passed through to AutoRest for the baseline
+   * (old) generation run.
+   */
+  oldArgs: string[];
+
+  /**
+   * The array of arguments passed through to AutoRest for the new generation
+   * run.
+   */
+  newArgs: string[];
+
+  /**
+   * The array of spec names that will be excluded for this language.  Any items
+   * in this array will be excluded from every SpecConfiguration in the
+   * RunConfiguration.
+   */
+  excludeSpecs?: string[];
+
+  /**
+   * Determines whether existing output for the baseline should be used.
+   * Defaults to "old" (baseline). "all" will cause existing output to be
+   * used for old and new runs, "none" will force old and new output to be
+   * regenerated.
+   */
+  useExistingOutput?: "none" | "old" | "all";
+}
+
+/**
+ * Defines configuration for set of languages and specs where an operation
+ * (comparison, baseline generation, etc) will be run.
+ */
+export interface RunConfiguration {
+  debug?: boolean;
+  specs: SpecConfiguration[];
+  languages: LanguageConfiguration[];
+}
+
+/**
+ * Loads a RunConfiguration object from the YAML file at configPath.
+ */
+export function loadConfiguration(configPath: string): RunConfiguration {
+  try {
+    return yaml.safeLoad(fs.readFileSync(configPath, "utf8"));
+  } catch (e) {
+    console.error(e);
+  }
+}

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -178,7 +178,7 @@ export async function runOperation(
       for (const specPath of specConfig.specPaths) {
         const fullSpecPath = path.resolve(specConfig.specRootPath, specPath);
         if (excludedSpecs.has(specPath)) {
-          console.log(chalk.white(`Skipping excluded spec: ${fullSpecPath}`));
+          console.log(chalk.gray(`Skipping excluded spec: ${fullSpecPath}`));
           continue;
         }
 

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -170,12 +170,17 @@ export async function runOperation(
   runConfig: RunConfiguration
 ): Promise<number> {
   for (const languageConfig of runConfig.languages) {
+    const excludedSpecs = new Set(languageConfig.excludeSpecs || []);
     console.log(
       `\n# Language Generator: ${chalk.greenBright(languageConfig.language)}\n`
     );
     for (const specConfig of runConfig.specs) {
       for (const specPath of specConfig.specPaths) {
         const fullSpecPath = path.resolve(specConfig.specRootPath, specPath);
+        if (excludedSpecs.has(specPath)) {
+          console.log(chalk.white(`Skipping excluded spec: ${fullSpecPath}`));
+          continue;
+        }
 
         await operation.runForSpec(
           {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -50,19 +50,19 @@ export type AutoRestLanguage =
  * A list of the names of all supported AutoRest language generators.
  */
 export const AutoRestLanguages: AutoRestLanguage[] = [
-  "typescript",
-  "python",
-  "java",
-  "csharp",
-  "powershell",
-  "go"
+  "typescript"
+  // "python",
+  // "java",
+  // "csharp",
+  // "powershell",
+  // "go"
 ];
 
 /**
  * Gets the base AutoRestResult by gathering the output files under the
  * given outputPath.
  */
-function getBaseResult(outputPath: string): AutoRestResult {
+export function getBaseResult(outputPath: string): AutoRestResult {
   return {
     outputPath,
     outputFiles: getPathsRecursively(outputPath).map(p =>


### PR DESCRIPTION
This change adds support for a simple YAML-based configuration file format for configuring language and spec combinations for regression testing and baseline generation.  Here's an example spec that I plan to add to `Azure/autorest` (after adding the remaining specs):

```yaml
debug: false
specs:
  - specRootPath: "../node_modules/@microsoft.azure/autorest.testserver/swagger"
    specPaths:
    - "body-string.json"
    - "body-complex.json"
languages:
  - language: typescript
    excludeSpecs:
      - additional-properties.json
    outputPath: "../core/test/generated/typescript"
    oldArgs:
      - --v3
      - --version:3.0.6200
      - --package-name:test-package
      - --use:@autorest/typescript@0.1.0-dev.20200203.1
    newArgs:
      - --v3
      - --version:../core
      - --package-name:test-package
      - --use:@autorest/typescript@0.1.0-dev.20200203.1
```

This new change improves the existing design to enable multiple languages and spec roots to be specified in the configuration so that they can all be run with one invocation of `autorest-compare`.  You can also pick a single language from the configuration to run by using the `--language:<language name>` parameter.