### PR TITLE
Add Python language comparison support

### DIFF
--- a/.scripts/get-ast.js
+++ b/.scripts/get-ast.js
@@ -1,0 +1,52 @@
+const fs = require("fs");
+const Parser = require("tree-sitter");
+
+// USAGE:
+// node .scripts/get-ast.js --python file-to-parse.py
+
+// Set up the parser
+const parser = new Parser();
+switch (process.argv[2]) {
+  case "--typescript":
+    const TypeScript = require("tree-sitter-typescript/typescript");
+    parser.setLanguage(TypeScript);
+    break;
+  case "--python":
+    const Python = require("tree-sitter-python");
+    parser.setLanguage(Python);
+    break;
+  default:
+    console.error(
+      "A language argument is needed to choose a Tree Sitter parser."
+    );
+    process.exit(1);
+}
+
+function prettyPrint(rootNode) {
+  let indentLevel = -1;
+  const printed = rootNode.toString();
+  for (let i = 0; i < printed.length; i++) {
+    if (printed[i] === "(") {
+      indentLevel++;
+      process.stdout.write("\n" + "  ".repeat(indentLevel));
+    } else if (printed[i] === ")") {
+      indentLevel--;
+      // process.stdout.write("\n");
+    }
+
+    process.stdout.write(printed[i]);
+  }
+}
+
+const fileToParse = process.argv[3];
+if (fileToParse) {
+  const contents = fs.readFileSync(fileToParse).toString();
+  const parsedContents = parser.parse(contents);
+  prettyPrint(parsedContents.rootNode);
+  console.log();
+} else {
+  console.error(
+    "A path to a source file must be provided as the second argument."
+  );
+  process.exit(1);
+}

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ wish to use.  Specific usage scenarios are described in the following sections.
 * Comparing the Python output between two versions of `@autorest/modelerfour`:
 
   ```shell
-  autorest-compare --compare --language:python --spec-path path/to/spec.json \
-    --output-path path/to/output \
+  autorest-compare --compare --language:python --spec-path:path/to/spec.json \
+    --output-path:path/to/output \
     --old-args --use:@autorest/modelerfour@4.1.59 \
     --new-args --use:@autorest/modelerfour@4.1.60
   ```
@@ -85,7 +85,7 @@ wish to use.  Specific usage scenarios are described in the following sections.
     --spec-root-path:../path/to/azure-rest-api-specs/specifications \
     --spec-path:redis/resource-manager \
     --spec-path:keyvault/resource-manager \
-    --output-path path/to/output \
+    --output-path:path/to/output \
     --old-args --version:^2.0.0 \
     --new-args --version:3.0.6179
   ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/compare",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/compare",
-  "version": "0.1.2",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1141,6 +1141,14 @@
       "requires": {
         "nan": "^2.14.0",
         "prebuild-install": "^5.0.0"
+      }
+    },
+    "tree-sitter-python": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-python/-/tree-sitter-python-0.16.0.tgz",
+      "integrity": "sha512-DtMdqQeIJpibuSacNi4uLb3fKLEqZO18um6iKd7zLgKFU7mgPOaC+PPTGzRY8YEcW9zrcBbC++msMFphw1buXA==",
+      "requires": {
+        "nan": "^2.4.0"
       }
     },
     "tree-sitter-typescript": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,8 @@
   "requires": true,
   "dependencies": {
     "@autorest/autorest": {
-      "version": "https://github.com/Azure/autorest/releases/download/autorest-3.0.6165/autorest-autorest-3.0.6165.tgz",
-      "integrity": "sha512-/2v0HtD9ppOubYVZMhpThAVc7dgsD6BIzRSVt0FsU8LUKliaKNB6hnVfe2Lpx3HhPPvSBT8N/CGH7XdE3V7LfQ=="
+      "version": "https://github.com/Azure/autorest/releases/download/autorest-3.0.6194/autorest-autorest-3.0.6194.tgz",
+      "integrity": "sha512-gcLvIWgvuhXEPHnlY3QMlF/xr91RiY3Kl+w2WTTAzG692JcWV8BuQ1bo/sZZicsW3YDhuK9d3/EG9ycHl83Ojg=="
     },
     "@types/color-name": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:unit": "ts-mocha -p tsconfig.json test/**/*.spec.ts",
     "test-run": "ts-node src/index.ts --typescript --spec-path:redis/resource-manager --spec-root-path:../azure-rest-api-specs/specification --output-path:generated/ --compare-base --version:^2.0.0 --compare-next --version:3.0.6170",
     "test-generate": "ts-node src/index.ts --generate-baseline --typescript --spec-path:redis/resource-manager --spec-root-path:../azure-rest-api-specs/specification --output-path:generated/ --compare-base --version:^2.0.0 --compare-next --version:3.0.6170",
+    "test-python": "ts-node src/index.ts --python --output-path:generated/python/ --spec-path:body-string.json --spec-root-path:/home/daviwil/Projects/Code/autorest.modelerfour/modelerfour/node_modules/@microsoft.azure/autorest.testserver/__files/ --compare-old --v3 --version=3.0.6199 --use=@autorest/python@5.0.0_20200124 --use:@autorest/modelerfour@4.3.142 --debug --compare-new --v3 --version=3.0.6199 --use=@autorest/python@5.0.0_20200124  --use:/home/daviwil/Projects/Code/autorest.modelerfour/modelerfour --debug --verbose",
     "build": "tsc -p ."
   },
   "repository": {
@@ -31,6 +32,7 @@
     "diff": "^4.0.1",
     "js-yaml": "^3.13.1",
     "tree-sitter": "^0.16.0",
+    "tree-sitter-python": "^0.16.0",
     "tree-sitter-typescript": "^0.16.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/Azure/autorest.compare#readme",
   "dependencies": {
-    "@autorest/autorest": "https://github.com/Azure/autorest/releases/download/autorest-3.0.6165/autorest-autorest-3.0.6165.tgz",
+    "@autorest/autorest": "https://github.com/Azure/autorest/releases/download/autorest-3.0.6194/autorest-autorest-3.0.6194.tgz",
     "@types/diff": "^4.0.2",
     "@types/js-yaml": "^3.12.2",
     "chalk": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/compare",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Compares the output between two AutoRest runs to check for material differences.",
   "main": "dist/index.js",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -193,8 +193,11 @@ function getCompareConfiguration(args: string[]): RunConfiguration {
     );
   }
 
-  // Resolve paths relative to configuration file
-  const fullConfigPath = path.dirname(path.resolve(configPath));
+  // Resolve paths relative to configuration file or the current directory
+  const fullConfigPath = configPath
+    ? path.dirname(path.resolve(configPath))
+    : process.cwd();
+
   runConfig = {
     ...runConfig,
     specs: runConfig.specs.map(resolveSpecRootPath(fullConfigPath)),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -168,8 +168,10 @@ function getCompareConfiguration(args: string[]): RunConfiguration {
 
   // Add debug flags if --debug was set globally
   if (runConfig.debug) {
-    languageConfig.oldArgs.push("--debug");
-    languageConfig.newArgs.push("--debug");
+    for (let language of runConfig.languages) {
+      language.oldArgs.push("--debug");
+      language.newArgs.push("--debug");
+    }
   }
 
   if (configPath === undefined && languageConfig.language === undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ Output Arguments
                                                - old: Uses existing old output folder
                                                - all: Uses existing folders for old and new output
 
-                                                
+
 Comparison Arguments
 
   --old-args <AutoRest arguments>              Indicates that what follows are arguments to AutoRest to generate the "old"

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -1,0 +1,220 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as Parser from "tree-sitter";
+import * as Python from "tree-sitter-python";
+import {
+  CompareResult,
+  FileDetails,
+  prepareResult,
+  compareItems,
+  MessageType,
+  compareText,
+  NamedItem
+} from "../comparers";
+
+interface ParameterDetails {
+  name: string;
+  type?: string;
+  defaultValue?: string;
+}
+
+interface MethodDetails {
+  name: string;
+  body: string;
+  returnType?: string;
+  parameters: ParameterDetails[];
+}
+
+interface AssignmentDetails {
+  name: string;
+  value: string;
+}
+
+interface ClassDetails {
+  name: string;
+  superclasses: SuperclassDetails[];
+  methods: MethodDetails[];
+  assignments: AssignmentDetails[];
+}
+
+export interface SuperclassDetails extends NamedItem {}
+
+export interface SourceDetails {
+  classes: ClassDetails[];
+}
+
+export function extractParameter(
+  paramNode: Parser.SyntaxNode
+): ParameterDetails {
+  const nameNode = (paramNode as any).nameNode;
+  const typeNode = (paramNode as any).typeNode;
+  const valueNode = (paramNode as any).valueNode;
+
+  return {
+    name: nameNode ? nameNode.text : paramNode.text,
+    type: typeNode?.text,
+    defaultValue: valueNode?.text
+  };
+}
+
+export function extractMethod(methodNode: Parser.SyntaxNode): MethodDetails {
+  const bodyNode = methodNode.namedChildren.find(node => node.type === "block");
+  const returnTypeNode = (methodNode as any).returnTypeNode;
+  const parameterNodes = (methodNode as any).parametersNode.namedChildren.filter(
+    // Comments in parameter lists are being included here, skip them
+    p => !p.text.startsWith("#")
+  );
+
+  return {
+    name: (methodNode as any).nameNode.text,
+    returnType: returnTypeNode ? returnTypeNode.text : "",
+    body: bodyNode.text,
+    parameters: parameterNodes.map(extractParameter)
+  };
+}
+
+export function compareParameter(
+  oldParameter: ParameterDetails,
+  newParameter: ParameterDetails
+): CompareResult {
+  return prepareResult(oldParameter.name, MessageType.Changed, [
+    compareText("Type", oldParameter.type, newParameter.type),
+    compareText(
+      "Default Value",
+      oldParameter.defaultValue,
+      newParameter.defaultValue
+    )
+  ]);
+}
+
+export function compareMethod(
+  oldMethod: MethodDetails,
+  newMethod: MethodDetails
+): CompareResult {
+  return prepareResult(oldMethod.name, MessageType.Changed, [
+    compareItems(
+      "Parameters",
+      MessageType.Outline,
+      oldMethod.parameters,
+      newMethod.parameters,
+      compareParameter,
+      true
+    ),
+    compareText("Body", oldMethod.body, newMethod.body),
+    compareText("Return Type", oldMethod.returnType, newMethod.returnType)
+  ]);
+}
+
+export function extractAssignment(
+  expressionNode: Parser.SyntaxNode
+): AssignmentDetails {
+  const assignmentNode = expressionNode.namedChildren[0];
+  const [leftSideNode, rightSideNode] = assignmentNode.namedChildren;
+
+  return {
+    name: leftSideNode.text,
+    value: rightSideNode.text
+  };
+}
+
+export function compareAssignment(
+  oldAssignment: AssignmentDetails,
+  newAssignment: AssignmentDetails
+): CompareResult {
+  return prepareResult(oldAssignment.name, MessageType.Changed, [
+    compareText("Value", oldAssignment.value, newAssignment.value)
+  ]);
+}
+
+export function extractClass(classNode: Parser.SyntaxNode): ClassDetails {
+  const bodyNode = classNode.namedChildren.find(node => node.type === "block");
+  const superclasses = (classNode as any).superclassesNode;
+
+  return {
+    name: (classNode as any).nameNode.text,
+    superclasses: superclasses
+      ? superclasses.namedChildren.map(s => {
+          return {
+            name: s.text
+          };
+        })
+      : [],
+    methods: bodyNode.namedChildren
+      .filter(node => node.type === "function_definition")
+      .map(extractMethod),
+    assignments: bodyNode.namedChildren
+      .filter(
+        node =>
+          node.type === "expression_statement" &&
+          node.namedChildren[0].type === "assignment"
+      )
+      .map(extractAssignment)
+  };
+}
+
+export function compareClass(
+  oldClass: ClassDetails,
+  newClass: ClassDetails
+): CompareResult {
+  return prepareResult(oldClass.name, MessageType.Changed, [
+    compareItems(
+      "Superclasses",
+      MessageType.Outline,
+      oldClass.superclasses,
+      newClass.superclasses,
+      t => undefined // There's nothing to compare other than existence
+    ),
+    compareItems(
+      "Methods",
+      MessageType.Outline,
+      oldClass.methods,
+      newClass.methods,
+      compareMethod
+    ),
+    compareItems(
+      "Fields",
+      MessageType.Outline,
+      oldClass.assignments,
+      newClass.assignments,
+      compareAssignment
+    )
+  ]);
+}
+
+export function extractSourceDetails(parseTree: Parser.Tree): SourceDetails {
+  return {
+    classes: parseTree.rootNode
+      .descendantsOfType("class_definition")
+      .map(extractClass)
+  };
+}
+
+const parser = new Parser();
+parser.setLanguage(Python);
+
+export function parseFile(filePath: string): Parser.Tree {
+  const contents = fs.readFileSync(filePath).toString();
+  return parser.parse(contents);
+}
+
+export function compareFile(
+  oldFile: FileDetails,
+  newFile: FileDetails
+): CompareResult {
+  const oldSource = extractSourceDetails(
+    parseFile(path.resolve(oldFile.basePath, oldFile.name))
+  );
+  const newSource = extractSourceDetails(
+    parseFile(path.resolve(newFile.basePath, newFile.name))
+  );
+
+  return prepareResult(oldFile.name, MessageType.Changed, [
+    compareItems(
+      "Classes",
+      MessageType.Outline,
+      oldSource.classes,
+      newSource.classes,
+      compareClass
+    )
+  ]);
+}

--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -67,7 +67,7 @@ export function extractMethod(methodNode: Parser.SyntaxNode): MethodDetails {
 
   return {
     name: (methodNode as any).nameNode.text,
-    returnType: returnTypeNode ? returnTypeNode.text : "",
+    returnType: returnTypeNode ? returnTypeNode.text : undefined,
     body: bodyNode.text,
     parameters: parameterNodes.map(extractParameter)
   };

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -8,6 +8,7 @@ import { RunConfiguration, LanguageConfiguration } from "./config";
 import { runAutoRest, AutoRestResult, getBaseResult } from "./runner";
 import { compareOutputFiles, CompareResult } from "./comparers";
 import { compareFile as compareTypeScriptFile } from "./languages/typescript";
+import { compareFile as comparePythonFile } from "./languages/python";
 import { printCompareMessage } from "./printer";
 
 export abstract class Operation {
@@ -92,7 +93,8 @@ export class CompareOperation extends Operation {
 
     const compareResult = compareOutputFiles(oldResult, newResult, {
       comparersByType: {
-        ts: compareTypeScriptFile
+        ts: compareTypeScriptFile,
+        py: comparePythonFile
       }
     });
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -123,7 +123,9 @@ export function runAutoRest(
     });
 
     let versionArg = autoRestArgs.find(arg => arg.startsWith("--version"));
-    let [_, version] = parseArgument(versionArg);
+    let [_, version] = versionArg
+      ? parseArgument(versionArg)
+      : [null, "unspecified"];
 
     autoRestProcess.on("exit", exitCode => {
       if (exitCode > 0) {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -50,8 +50,8 @@ export type AutoRestLanguage =
  * A list of the names of all supported AutoRest language generators.
  */
 export const AutoRestLanguages: AutoRestLanguage[] = [
-  "typescript"
-  // "python",
+  "typescript",
+  "python"
   // "java",
   // "csharp",
   // "powershell",

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -93,7 +93,7 @@ export function runAutoRest(
       `--${language}`,
 
       // The output-folder where generated files go
-      `--${language}.output-folder=\"${outputPath}\"`,
+      `--${language}.output-folder="${outputPath}"`,
 
       // Clear the output folder before generating
       `--${language}.clear-output-folder`,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -131,8 +131,7 @@ export function runAutoRest(
       if (exitCode > 0) {
         reject(
           new Error(
-            `AutoRest (${version}) exited with non-zero code:\n\n${errorOutput ||
-              normalOutput}`
+            `AutoRest (${version}) exited with non-zero code:\n\n${errorOutput}\n\nCommand Output:\n\n${normalOutput}`
           )
         );
       } else {

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,6 +9,11 @@ import * as path from "path";
  */
 export function getPathsRecursively(folderPath: string): string[] {
   let filesInPath = [];
+
+  if (!fs.existsSync(folderPath)) {
+    return [];
+  }
+
   for (const childPath of fs.readdirSync(folderPath)) {
     const rootedPath = path.join(folderPath, childPath);
     if (fs.statSync(rootedPath).isDirectory()) {

--- a/test/artifacts/python/new/models.py
+++ b/test/artifacts/python/new/models.py
@@ -1,0 +1,55 @@
+from typing import Optional
+
+import msrest.serialization
+
+class Error(msrest.serialization.Model2):
+    """Error.
+
+    :param status:
+    :type status: int
+    :param message:
+    :type message: str
+    """
+    _EXCEPTION_TYPE = ErrorException
+    _attribute_map = {
+        'status': {'key': 'status', 'type': 'str'},
+        'message': {'key': 'message', 'type': 'str'},
+    }
+
+    def __init__(
+        self,
+        *,
+        status: Optional[int] = None,
+        message: Optional[str] = "gorp",
+        **kwargs
+    ):
+        super(Error, self).__init__(**kwargs)
+        self.status = status
+        self.message = message
+
+
+class RefColorConstant(msrest.serialization.Model2):
+    """RefColorConstant.
+
+    Variables are only populated by the server, and will be ignored when sending a request.
+
+    All required parameters must be populated in order to send to Azure.
+
+    :ivar color_constant: Required. Referenced Color Constant Description. Default value: "green-
+     color".
+    :vartype color_constant: str
+    :param field1: Sample string.
+    :type field1: str
+    """
+
+    color_constant = "purple-color"
+    other_thing = "whatever"
+
+    def __init__(
+        self,
+        *,
+        field1: Optional[str] = 22,
+        **kwargs
+    ): InvalidButOK
+        super(RefColorConstant, self).__init__(**kwargs)
+        self.field1 = field1

--- a/test/artifacts/python/old/models.py
+++ b/test/artifacts/python/old/models.py
@@ -1,0 +1,54 @@
+from typing import Optional
+
+import msrest.serialization
+
+class Error(msrest.serialization.Model):
+    """Error.
+
+    :param status:
+    :type status: int
+    :param message:
+    :type message: str
+    """
+
+    _attribute_map = {
+        'status': {'key': 'status', 'type': 'int'},
+        'message': {'key': 'message', 'type': 'str'},
+    }
+
+    def __init__(
+        self,
+        *,
+        status: Optional[int] = None,
+        message: Optional[str] = None,
+        **kwargs
+    ):
+        super(Error, self).__init__(**kwargs)
+        self.status = status
+        self.message = message
+
+
+class RefColorConstant(msrest.serialization.Model):
+    """RefColorConstant.
+
+    Variables are only populated by the server, and will be ignored when sending a request.
+
+    All required parameters must be populated in order to send to Azure.
+
+    :ivar color_constant: Required. Referenced Color Constant Description. Default value: "green-
+     color".
+    :vartype color_constant: str
+    :param field1: Sample string.
+    :type field1: str
+    """
+
+    color_constant = "green-color"
+
+    def __init__(
+        self,
+        *,
+        field1: Optional[str] = None,
+        **kwargs
+    ):
+        super(RefColorConstant, self).__init__(**kwargs)
+        self.field1 = field1

--- a/test/languages/python.spec.ts
+++ b/test/languages/python.spec.ts
@@ -2,33 +2,347 @@ import * as assert from "assert";
 import * as path from "path";
 import {
   parseFile,
+  compareFile,
   extractSourceDetails,
   SourceDetails
-  // compareClass,
-  // compareInterface,
-  // compareParameter,
-  // compareMethod
 } from "../../src/languages/python";
 import { MessageType } from "../../src/comparers";
 
 describe.only("Python Parser", function() {
   it("extracts semantic elements from source", function() {
     const parseTree = parseFile(
-      path.resolve(__dirname, "../artifacts/python/old/test.py")
+      path.resolve(__dirname, "../artifacts/python/old/models.py")
     );
     const sourceDetails: SourceDetails = extractSourceDetails(parseTree);
 
     assert.deepEqual(sourceDetails, {
       classes: [
         {
-          name: "Operations",
-          methods: [],
-          assignments: []
+          name: "Error",
+          superclasses: [
+            {
+              name: "msrest.serialization.Model"
+            }
+          ],
+          methods: [
+            {
+              name: "__init__",
+              body:
+                "super(Error, self).__init__(**kwargs)\n        self.status = status\n        self.message = message",
+              parameters: [
+                {
+                  name: "self",
+                  type: undefined,
+                  defaultValue: undefined
+                },
+                {
+                  name: "*",
+                  type: undefined,
+                  defaultValue: undefined
+                },
+                {
+                  name: "status",
+                  type: "Optional[int]",
+                  defaultValue: "None"
+                },
+                {
+                  name: "message",
+                  type: "Optional[str]",
+                  defaultValue: "None"
+                },
+                {
+                  name: "**kwargs",
+                  type: undefined,
+                  defaultValue: undefined
+                }
+              ],
+              returnType: undefined
+            }
+          ],
+          assignments: [
+            {
+              name: "_attribute_map",
+              value:
+                "{\n        'status': {'key': 'status', 'type': 'int'},\n        'message': {'key': 'message', 'type': 'str'},\n    }"
+            }
+          ]
         },
         {
-          name: "RedisFirewallRule",
-          methods: [],
-          assignments: []
+          name: "RefColorConstant",
+          superclasses: [
+            {
+              name: "msrest.serialization.Model"
+            }
+          ],
+          assignments: [
+            {
+              name: "color_constant",
+              value: '"green-color"'
+            }
+          ],
+          methods: [
+            {
+              name: "__init__",
+              body:
+                "super(RefColorConstant, self).__init__(**kwargs)\n        self.field1 = field1",
+              parameters: [
+                {
+                  name: "self",
+                  type: undefined,
+                  defaultValue: undefined
+                },
+                {
+                  name: "*",
+                  type: undefined,
+                  defaultValue: undefined
+                },
+                {
+                  name: "field1",
+                  type: "Optional[str]",
+                  defaultValue: "None"
+                },
+                {
+                  name: "**kwargs",
+                  type: undefined,
+                  defaultValue: undefined
+                }
+              ],
+              returnType: undefined
+            }
+          ]
+        }
+      ]
+    });
+  });
+
+  it("compares source files and finds changes", () => {
+    const basePath = path.resolve(__dirname, "../artifacts/python");
+    const compareResult = compareFile(
+      {
+        name: "models.py",
+        basePath: basePath + "/old/"
+      },
+      {
+        name: "models.py",
+        basePath: basePath + "/new/"
+      }
+    );
+
+    assert.deepEqual(compareResult, {
+      message: "models.py",
+      type: MessageType.Changed,
+      children: [
+        {
+          message: "Classes",
+          type: MessageType.Outline,
+          children: [
+            {
+              message: "Error",
+              type: MessageType.Changed,
+              children: [
+                {
+                  message: "Superclasses",
+                  type: MessageType.Outline,
+                  children: [
+                    {
+                      message: "msrest.serialization.Model",
+                      type: MessageType.Removed
+                    },
+                    {
+                      message: "msrest.serialization.Model2",
+                      type: MessageType.Added
+                    }
+                  ]
+                },
+                {
+                  message: "Methods",
+                  type: MessageType.Outline,
+                  children: [
+                    {
+                      message: "__init__",
+                      type: MessageType.Changed,
+                      children: [
+                        {
+                          message: "Parameters",
+                          type: MessageType.Outline,
+                          children: [
+                            {
+                              message: "message",
+                              type: MessageType.Changed,
+                              children: [
+                                {
+                                  message: "Default Value",
+                                  type: MessageType.Outline,
+                                  children: [
+                                    {
+                                      message: "None",
+                                      type: MessageType.Removed
+                                    },
+                                    {
+                                      message: '"gorp"',
+                                      type: MessageType.Added
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  message: "Fields",
+                  type: MessageType.Outline,
+                  children: [
+                    {
+                      message: "_EXCEPTION_TYPE",
+                      type: MessageType.Added
+                    },
+                    {
+                      message: "_attribute_map",
+                      type: MessageType.Changed,
+                      children: [
+                        {
+                          message: "Value",
+                          type: MessageType.Outline,
+                          children: [
+                            {
+                              message: "{\n",
+                              type: MessageType.Plain
+                            },
+                            {
+                              message:
+                                "        'status': {'key': 'status', 'type': 'int'},\n",
+                              type: MessageType.Removed
+                            },
+                            {
+                              message:
+                                "        'status': {'key': 'status', 'type': 'str'},\n",
+                              type: MessageType.Added
+                            },
+                            {
+                              message:
+                                "        'message': {'key': 'message', 'type': 'str'},\n    }",
+                              type: MessageType.Plain
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              message: "RefColorConstant",
+              type: MessageType.Changed,
+              children: [
+                {
+                  message: "Superclasses",
+                  type: MessageType.Outline,
+                  children: [
+                    {
+                      message: "msrest.serialization.Model",
+                      type: MessageType.Removed
+                    },
+                    {
+                      message: "msrest.serialization.Model2",
+                      type: MessageType.Added
+                    }
+                  ]
+                },
+                {
+                  message: "Methods",
+                  type: 0,
+                  children: [
+                    {
+                      message: "__init__",
+                      type: 4,
+                      children: [
+                        {
+                          message: "Parameters",
+                          type: 0,
+                          children: [
+                            {
+                              message: "field1",
+                              type: 4,
+                              children: [
+                                {
+                                  message: "Default Value",
+                                  type: 0,
+                                  children: [
+                                    {
+                                      message: "None",
+                                      type: 3
+                                    },
+                                    {
+                                      message: "22",
+                                      type: 2
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          message: "Body",
+                          type: 0,
+                          children: [
+                            {
+                              message:
+                                "super(RefColorConstant, self).__init__(**kwargs)\n        self.field1 = field1",
+                              type: 3
+                            },
+                            {
+                              message: "InvalidButOK",
+                              type: 2
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  message: "Fields",
+                  type: MessageType.Outline,
+                  children: [
+                    {
+                      message: "color_constant",
+                      type: MessageType.Changed,
+                      children: [
+                        {
+                          message: "Value",
+                          type: MessageType.Outline,
+                          children: [
+                            {
+                              message: '"green-color"',
+                              type: MessageType.Removed
+                            },
+                            {
+                              message: '"purple-color"',
+                              type: MessageType.Added
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      message: "other_thing",
+                      type: MessageType.Added
+                    },
+                    {
+                      message: "self.field1",
+                      type: MessageType.Added
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ]
     });

--- a/test/languages/python.spec.ts
+++ b/test/languages/python.spec.ts
@@ -1,0 +1,36 @@
+import * as assert from "assert";
+import * as path from "path";
+import {
+  parseFile,
+  extractSourceDetails,
+  SourceDetails
+  // compareClass,
+  // compareInterface,
+  // compareParameter,
+  // compareMethod
+} from "../../src/languages/python";
+import { MessageType } from "../../src/comparers";
+
+describe.only("Python Parser", function() {
+  it("extracts semantic elements from source", function() {
+    const parseTree = parseFile(
+      path.resolve(__dirname, "../artifacts/python/old/test.py")
+    );
+    const sourceDetails: SourceDetails = extractSourceDetails(parseTree);
+
+    assert.deepEqual(sourceDetails, {
+      classes: [
+        {
+          name: "Operations",
+          methods: [],
+          assignments: []
+        },
+        {
+          name: "RedisFirewallRule",
+          methods: [],
+          assignments: []
+        }
+      ]
+    });
+  });
+});

--- a/test/languages/typescript.spec.ts
+++ b/test/languages/typescript.spec.ts
@@ -5,7 +5,6 @@ import {
   extractSourceDetails,
   SourceDetails,
   compareClass,
-  compareInterface,
   compareParameter,
   compareMethod
 } from "../../src/languages/typescript";


### PR DESCRIPTION
This change adds Python language support to AutoRest Compare so that `@autorest/python` output can be used in regression tests for the AutoRest v3 pipeline.  I'm using [`tree-sitter-python`](https://github.com/tree-sitter/tree-sitter-python) to extract the following syntax elements from the generated output:

- Classes and their base class lists
- Methods, parameter lists, and type annotations for parameters and return types
- Method bodies are diffed as text
- Class attribute assignments (used for operation specs) are diffed as text

This covers the majority of patterns that I see in generated Python code.  Let me know if there are any other patterns that might exhibit "breaking changes" so that I can add them to the comparator!

A screenshot of comparison output for `body-string.json` with the "new" output tweaked by hand to introduce changes:

![2020-02-25-141137_910x1133_scrot](https://user-images.githubusercontent.com/79405/75292336-cb162500-57d8-11ea-9114-27c0e6a7d02f.png)

**Remaining Work**

- [x] Flesh out unit tests for Python syntax extractor
- [x] Add unit tests for Python comparator

/cc @johanste @lmazuel 