### PR TITLE
Add the --output-folder parameter for consistent generator output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@autorest/compare",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@autorest/autorest": {
-      "version": "https://github.com/Azure/autorest/releases/download/autorest-3.0.6194/autorest-autorest-3.0.6194.tgz",
-      "integrity": "sha512-gcLvIWgvuhXEPHnlY3QMlF/xr91RiY3Kl+w2WTTAzG692JcWV8BuQ1bo/sZZicsW3YDhuK9d3/EG9ycHl83Ojg=="
+      "version": "https://github.com/Azure/autorest/releases/download/autorest-3.0.6209/autorest-autorest-3.0.6209.tgz",
+      "integrity": "sha512-q6rQZEGTng4FmMbD7rNgSWKyI1SXsFnGbP4gwcqLSKCsZ31P6phQx7FNnwImlkp7VDCATg7vYEBD1kd4pxjsOA=="
     },
     "@types/color-name": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/compare",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Compares the output between two AutoRest runs to check for material differences.",
   "main": "dist/index.js",
   "bin": {
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/Azure/autorest.compare#readme",
   "dependencies": {
-    "@autorest/autorest": "https://github.com/Azure/autorest/releases/download/autorest-3.0.6194/autorest-autorest-3.0.6194.tgz",
+    "@autorest/autorest": "https://github.com/Azure/autorest/releases/download/autorest-3.0.6209/autorest-autorest-3.0.6209.tgz",
     "@types/diff": "^4.0.2",
     "@types/js-yaml": "^3.12.2",
     "chalk": "^3.0.0",

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -92,8 +92,10 @@ export function runAutoRest(
       // The language generator to use
       `--${language}`,
 
-      // The output-folder where generated files go
-      `--${language}.output-folder="${outputPath}"`,
+      // The output-folder where generated files are written.  Specify both
+      // styles of option due to inconsistencies between generators.
+      `--output-folder="${outputPath}"`,
+      `--${language}.output-folder="$(output-folder)"`,
 
       // Clear the output folder before generating
       `--${language}.clear-output-folder`,


### PR DESCRIPTION
This change updates the AutoRest runner to use the `--output-folder` parameter and back it up with the `--<language>.output-folder` parameter to ensure that the parameter works for language generators that don't explicitly export a scope name for their language.  This issue was encountered with the latest development releases of the Python generator.