### PR TITLE
Update tree-sitter to 0.17.x, tree-sitter-typescript introduced a breaking change

### DIFF
--- a/.scripts/pr-validation.yml
+++ b/.scripts/pr-validation.yml
@@ -47,7 +47,7 @@ jobs:
           versionSpec: "14.x"
         displayName: "Install Node.js"
 
-      - script: npm install -g npm
+      - script: npm install -g npm@6
         displayName: "Update npm"
 
       - script: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/compare",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,9 +14,9 @@
       "integrity": "sha512-mIenTfsIe586/yzsyfql69KRnA75S8SVXQbTLpDejRrjH0QSJcpu3AUOi/Vjnt9IOsXKxPhJfGpQUNMueIU1fQ=="
     },
     "@types/js-yaml": {
-      "version": "3.12.5",
-      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.5.tgz",
-      "integrity": "sha512-JCcp6J0GV66Y4ZMDAQCXot4xprYB+Zfd3meK9+INSJeVZwJmHAW30BBEEkPzXswMXuiyReUGOP3GxrADc9wPww=="
+      "version": "3.12.6",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-3.12.6.tgz",
+      "integrity": "sha512-cK4XqrLvP17X6c0C8n4iTbT59EixqyXL3Fk8/Rsk4dF3oX4dg70gYUXrXVUUHpnsGMPNlTQMqf+TVmNPX6FmSQ=="
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -32,9 +32,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.8.tgz",
-      "integrity": "sha512-D4k2kNi0URNBxIRCb1khTnkWNHv8KSL1owPmS/K5e5t8B2GzMReY7AsJIY1BnP5KdlgC4rj9jk2IkDMasIE7xg==",
+      "version": "12.19.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.16.tgz",
+      "integrity": "sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q==",
       "dev": true
     },
     "ansi-colors": {
@@ -102,9 +102,9 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "bl": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.4.tgz",
+      "integrity": "sha512-7tdr4EpSd7jJ6tuQ21vu2ke8w7pNEstzj1O8wwq6sNNzO3UDi5MA8Gny/gquCj7r2C6fHudg8tKRGyjRgmvNxQ==",
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -540,9 +540,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.6.tgz",
-      "integrity": "sha512-IZUoxEjNjubzrmvzZU4lKP7OnYmX72XRl3sqkfJhBKweKi5rnGi5+IUdlj/H1M+Ip5JQ1WzaDMOBRY90Ajc5jg=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "is-buffer": {
       "version": "2.0.5",
@@ -1150,9 +1150,9 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "requires": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -1174,9 +1174,9 @@
       }
     },
     "tree-sitter": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.16.2.tgz",
-      "integrity": "sha512-1d9oNXVUWJGzpPyTwI7qBHoGZYLD4BU04bHSxj9PqRgR3URY8fXqk2LhFCu7AFBDQHifcinMxss5CqYXCTGcLQ==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.17.1.tgz",
+      "integrity": "sha512-obIe804bwfAGFMhTjQz0NXF75GDupCVXo7Sv0NVVdA3s/Q4ZI4mdirIN8cpw6bVhz/K1qgUdEuI3SEoOE/q75A==",
       "requires": {
         "nan": "^2.14.0",
         "prebuild-install": "^5.0.0"
@@ -1191,9 +1191,9 @@
       }
     },
     "tree-sitter-typescript": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.16.1.tgz",
-      "integrity": "sha512-jyU5yl4W6JPn66v2YbzaO1ClDcdDnj+7YQNZz3STgEiUooSjpWI1Ucgw+S/qEGbf0fMXsC0fucpP+/M1uc9ubw==",
+      "version": "0.16.3",
+      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.16.3.tgz",
+      "integrity": "sha512-qdRydjlnFuxwlkE/+oqOywzcKL2l3G1xkhR9DxDySGfF4JiMdYCTqJCWRUYaGnagJDZBF7wGWtHf5FGGXdLjNw==",
       "requires": {
         "nan": "^2.14.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/compare",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/compare",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Compares the output between two AutoRest runs to check for material differences.",
   "main": "dist/index.js",
   "bin": {
@@ -31,9 +31,9 @@
     "chalk": "^3.0.0",
     "diff": "^4.0.1",
     "js-yaml": "^3.13.1",
-    "tree-sitter": "^0.16.0",
+    "tree-sitter": "^0.17.0",
     "tree-sitter-python": "^0.16.0",
-    "tree-sitter-typescript": "^0.16.1"
+    "tree-sitter-typescript": "^0.16.3"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.7",


### PR DESCRIPTION
Seems like version `0.16.3` of `tree-sitter-typescript` caused this error

This is breaking global installation of autorest compare that will pull in the latest version of  `tree-sitter-typescript`
```
RangeError: Incompatible language version. Compatible range: 9 - 11. Got: 12
```